### PR TITLE
GDB-4550 Create a ColumnService that GETs the columns from a REST endpoint.

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,6 +5,7 @@ import {DragDropModule} from "@angular/cdk/drag-drop";
 import {TranslateModule} from "@ngx-translate/core";
 import {MatDialogModule} from "@angular/material/dialog";
 import {MapperModule} from "src/app/main/mapper/mapper.module";
+import {HttpClientTestingModule} from '@angular/common/http/testing';
 
 
 describe('AppComponent', () => {
@@ -12,6 +13,7 @@ describe('AppComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
+        HttpClientTestingModule,
         DragDropModule,
         TranslateModule.forRoot(),
         MatDialogModule,

--- a/src/app/main/mapper/mapper.component.spec.ts
+++ b/src/app/main/mapper/mapper.component.spec.ts
@@ -8,6 +8,10 @@ import {TranslateModule} from "@ngx-translate/core";
 import {MatDialogModule} from "@angular/material/dialog";
 import {IterationComponent} from "src/app/main/mapper/iteration/iteration.component";
 import {CellComponent} from "src/app/main/mapper/cell/cell.component";
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+
+
 
 describe('MapperComponent', () => {
   let component: MapperComponent;
@@ -25,7 +29,9 @@ describe('MapperComponent', () => {
       imports: [
         DragDropModule,
         TranslateModule.forRoot(),
-        MatDialogModule
+        MatDialogModule,
+        HttpClientTestingModule,
+        RouterTestingModule
       ]
     })
     .compileComponents();

--- a/src/app/main/mapper/mapper.component.ts
+++ b/src/app/main/mapper/mapper.component.ts
@@ -3,6 +3,9 @@ import {TabularDataService} from 'src/app/services/tabular-data.service';
 import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {MappingDefinitionImpl} from 'src/app/models/mapping-definition-impl';
 import {ModelManagementService} from 'src/app/services/model-management.service';
+import {Source} from 'src/app/models/source';
+import {ColumnsService} from 'src/app/services/rest/columns.service';
+import {OnDestroyMixin, untilComponentDestroyed} from '@w11k/ngx-componentdestroyed';
 
 export interface RdfDialogData {
   rdf: string;
@@ -13,14 +16,16 @@ export interface RdfDialogData {
   templateUrl: './mapper.component.html',
   styleUrls: ['./mapper.component.scss'],
 })
-export class MapperComponent implements OnInit {
-  sources: [];
+export class MapperComponent extends OnDestroyMixin implements OnInit {
+  sources: Array<Source>;
   mapping: MappingDefinitionImpl;
   rdf: string;
 
   constructor(private tabularDataService: TabularDataService,
               private modelManagementService: ModelManagementService,
+              private columnService: ColumnsService,
               public dialog: MatDialog) {
+    super();
   }
 
   drop() {
@@ -40,7 +45,12 @@ export class MapperComponent implements OnInit {
 
 
   ngOnInit(): void {
-    this.sources = this.tabularDataService.getData();
+    this.columnService.getColumns()
+        .pipe(untilComponentDestroyed(this))
+        .subscribe(
+            (data) => {
+              this.sources = data;
+            });
     this.mapping = this.modelManagementService.getStoredModelMapping();
   }
 }

--- a/src/app/services/rest/columns.service.spec.ts
+++ b/src/app/services/rest/columns.service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ColumnsService } from './columns.service';
-import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('ColumnsService', () => {
   let service: ColumnsService;
@@ -10,6 +11,7 @@ describe('ColumnsService', () => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
+        RouterTestingModule
       ]
     });
     service = TestBed.inject(ColumnsService);

--- a/src/app/services/rest/columns.service.ts
+++ b/src/app/services/rest/columns.service.ts
@@ -2,16 +2,25 @@ import {Injectable} from '@angular/core';
 import {RestService} from 'src/app/services/rest/rest.service';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
+import {map, switchMap} from 'rxjs/operators';
+import {Source} from 'src/app/models/source';
+
+import {ActivatedRoute} from '@angular/router';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ColumnsService extends RestService {
-  constructor(protected httpClient: HttpClient) {
-    super();
+  constructor(protected httpClient: HttpClient,
+              protected route: ActivatedRoute) {
+    super(route);
+    this.apiName = '/columns/';
   }
 
-  getColumnNames(): Observable<any> {
-    return this.httpClient.get<any>(`${this.apiUrl}/`, this.httpOptions);
+  getColumns(): Observable<Array<Source>> {
+    return this.getAPIURL().pipe(switchMap((fullUrl) => {
+      return this.httpClient.get<Array<Source>>(fullUrl, this.httpOptions)
+          .pipe(map((res) => res.map((c) => new Source(c))));
+    }));
   }
 }

--- a/src/app/services/rest/rest.service.ts
+++ b/src/app/services/rest/rest.service.ts
@@ -1,8 +1,26 @@
 import {environment} from 'src/environments/environment';
 import {HttpHeaders} from '@angular/common/http';
+import {ActivatedRoute, Params} from '@angular/router';
+import {Observable, of} from 'rxjs';
+import {switchMap} from 'rxjs/operators';
 
 export class RestService {
+  dataProviderID: Observable<string>;
+  apiName: String = '';
   apiUrl = environment.apiUrl;
+
+  constructor(protected route: ActivatedRoute) {
+    this.dataProviderID = this.route.queryParams.pipe(switchMap((params: Params) => {
+      return (params.dataProviderID) ? of(params.dataProviderID) : of('');
+    }));
+  }
+
+  getAPIURL() : Observable<string> {
+    return this.dataProviderID.pipe(switchMap((dataProviderID) => {
+      return of(`${this.apiUrl}` + this.apiName + ((dataProviderID) ? dataProviderID : ''));
+    }));
+  }
+
 
   httpHeaders = new HttpHeaders({
     'Content-Type': 'application/json',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  apiUrl: '',
+  apiUrl: '/rest/rdf-mapper',
   httpLoaderPrefix: './assets/i18n/',
   httpLoaderSuffix: '.js',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: '',
+  apiUrl: 'http://localhost:7200/rest/rdf-mapper',
   httpLoaderPrefix: './assets/i18n/',
   httpLoaderSuffix: '.json',
 };


### PR DESCRIPTION
Add RestService a dataProviderID fields obtained from the request parameters.

Add a reusable method to get the fullAPIURL.
Implement a ColumnService that gets columns from the /columns/ endpoint and using the provided dataProviderID. i.e http://localhost:7200/rest/rdf-mapper/columns/ontorefine:test/

Use the ColumnService instead of TabularDataProvider in the mapper component.
