### PR TITLE
GDB-4743 Fix javascript error and dialog OK button disabling condition

### DIFF
--- a/src/app/main/mapper/cell/cell.component.ts
+++ b/src/app/main/mapper/cell/cell.component.ts
@@ -315,7 +315,9 @@ export class CellComponent extends OnDestroyMixin implements OnInit {
   }
 
   getReasonableLongWord(word: string) {
-    return Helper.getReasonableLongWord(word, 7, 7);
+    if (word) {
+      return Helper.getReasonableLongWord(word, 7, 7);
+    }
   }
 
   public saveInputValueOnBlur($event: FocusEvent) {

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
@@ -490,6 +490,19 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
   }
 
   public isMappingInvalid() {
-    return !this.mapperForm.valid && !this.mapperForm.get('typeMapping').value;
+    const isTypeMapping = this.mapperForm.get('typeMapping').value;
+    const isFormValid = this.mapperForm.valid;
+    let invalid = true;
+    // When configuring a predicate the type and source could be changed simultaneously.
+    // In which case we consider the configuration as invalid if the form is invalid and
+    // the type is not "a".
+    // When configuring the object the type is set and can't be changed. So we consider
+    // configuration as invalid only when the form is invalid.
+    if (this.isObject()) {
+      invalid = !isFormValid;
+    } else {
+      invalid = !isFormValid && !isTypeMapping;
+    }
+    return invalid;
   }
 }


### PR DESCRIPTION
* Prevent invocation of the string value formatting function if the value is not defined to prevent errors
* Fix the condition for disabling the OK button in the dialog. We have two scenarios:

1. When configuring a predicate the type and source could be changed simultaneously. In which case we consider the configuration as invalid if the form is invalid and the type is not "a".

2. When configuring the object the type is set and can't be changed. So we consider configuration as invalid only when the form is invalid.