### PR TITLE
GDB-4739 properly clear prefix and transformation language

### DIFF
--- a/cypress/steps/edit-dialog-steps.ts
+++ b/cypress/steps/edit-dialog-steps.ts
@@ -89,6 +89,10 @@ class EditDialogSteps {
     return EditDialogSteps.getDialog().find('[appCypressData=transformation-section]');
   }
 
+  static getTransformationExpressionField() {
+    return this.getTransformationSection().find('[appCypressData=transformation-expression]');
+  }
+
   static selectGREL() {
     return this.getTransformationSection().find('[appCypressData=transformation-grel]').should('be.visible').click();
   }
@@ -98,7 +102,7 @@ class EditDialogSteps {
   }
 
   static completeGREL(value: string) {
-    this.getTransformationSection().find('[appCypressData=transformation-expression]').should('be.visible').type(value);
+    return this.getTransformationExpressionField().should('be.visible').type(value);
   }
 
   static completeDataTypeGREL(value: string) {
@@ -109,6 +113,22 @@ class EditDialogSteps {
     return this.getTransformationSection().find('[appCypressData=grel-preview]');
   }
 
+  static selectPrefix() {
+    return this.getTransformationSection().find(`[appCypressData=transformation-prefix]`).click();
+  }
+
+  static completePrefix(prefix: string) {
+    // emulate [esc] button hit in order to close the autocomplete
+    return this.getTransformationExpressionField().should('be.visible').type(`${prefix}{esc}`, {
+      parseSpecialCharSequences: true
+    });
+  }
+
+  static clearPrefix() {
+    return this.getTransformationExpressionField().should('be.visible').clear().type('{esc}', {
+      parseSpecialCharSequences: true
+    });
+  }
 
   static getDataTypeGRELPreview() {
     return this.getTypeSection().find('[appCypressData=datatype-grel-preview]');

--- a/cypress/steps/mapping-steps.ts
+++ b/cypress/steps/mapping-steps.ts
@@ -76,6 +76,10 @@ class MappingSteps {
     return MappingSteps.getTripleSubject(index).find('.ti-type');
   }
 
+  static getTripleSubjectPrefix(index: any) {
+    return MappingSteps.getTripleSubject(index).find('.ti-transform');
+  }
+
   static getTripleSubjectSource(index: any) {
     return MappingSteps.getTripleSubject(index).find('.ti-source');
   }

--- a/cypress/test/create-mapping.spec.ts
+++ b/cypress/test/create-mapping.spec.ts
@@ -136,4 +136,31 @@ describe('Create mapping', () => {
     MappingSteps.getTripleObjectType(4).should('contain', 'Unique BNode');
     MappingSteps.getTripleObjectType(5).should('contain', 'BNode');
   });
+
+  it('Should render prefix in a badge inside the cell', () => {
+    cy.route('GET', '/repositories/Movies/namespaces', 'fixture:namespaces.json');
+    cy.route('POST', '/repositories/Movies', 'fixture:create-mapping/autocomplete-response.json');
+    cy.route('POST', '/rest/rdf-mapper/preview/ontorefine:123', 'fixture:create-mapping/preview-response.json');
+    cy.route('GET', '/orefine/command/core/get-models/?project=123', 'fixture:empty-mapping-model.json');
+
+    // Given I have opened the application with an empty mapping
+    cy.visit('?dataProviderID=ontorefine:123');
+    cy.wait('@loadColumns');
+    // And I have created a triple
+    MappingSteps.completeTriple(0, '@duration', 'as', '@color');
+    MappingSteps.getTriples().should('have.length', 2);
+    // When I set a subject prefix
+    MappingSteps.editTripleSubject(0);
+    EditDialogSteps.selectPrefix();
+    EditDialogSteps.completePrefix('rdf');
+    EditDialogSteps.saveConfiguration();
+    // Then I expect to see the prefix in the subject cell
+    MappingSteps.getTripleSubjectPrefix(0).should('contain', 'rdf');
+    // When I remove the prefix
+    MappingSteps.editTripleSubject(0);
+    EditDialogSteps.clearPrefix();
+    EditDialogSteps.saveConfiguration();
+    // Then I expect the prefix to be removed from cell
+    MappingSteps.getTripleSubjectPrefix(0).should('not.be.visible');
+  });
 });

--- a/cypress/test/edit-mapping.spec.ts
+++ b/cypress/test/edit-mapping.spec.ts
@@ -270,7 +270,6 @@ describe('Edit mapping', () => {
     });
   });
 
-
   context('incomplete mapping', () => {
     it('Should not allow operations with incomplete mapping', () => {
       cy.route('GET', '/orefine/command/core/get-models/?project=123', 'fixture:edit-mapping/incomplete-mapping-model.json');
@@ -342,5 +341,5 @@ describe('Edit mapping', () => {
 
 function assertNotAllowedNotification() {
   MappingSteps.getNotification().should('contain', 'The operation is not allowed. You have an incomplete mapping.');
-  MappingSteps.getNotification().should('not.be.visible')
+  MappingSteps.getNotification().should('not.be.visible');
 }

--- a/src/app/services/model-construct.service.ts
+++ b/src/app/services/model-construct.service.ts
@@ -125,8 +125,11 @@ export class ModelConstructService {
   private setTypeTransformation(cellMapping: MappingBase, form, settings): void {
     if (settings.isTransformation && this.isAllowedExpression(form.expression, form.language)) {
       this.modelManagementService.setExpression(cellMapping, form.expression);
-      this.modelManagementService.setTransformationLanguage(cellMapping, form.language);
-      if (form.language === Language.Prefix.valueOf() && !settings.namespaces[form.expression]) {
+      // Transformation language should be cleared if the expression is not present.
+      // This would prevent showing an empty badge in the UI and also the mapping would be kept valid.
+      this.modelManagementService.setTransformationLanguage(cellMapping, form.language, form.expression);
+      // Should update the namespaces only if the expression is set
+      if (form.language === Language.Prefix.valueOf() && !settings.namespaces[form.expression] && form.expression) {
         settings.namespaces[form.expression] = settings.repoNamespaces[form.expression];
       }
     }

--- a/src/app/services/model-management.service.ts
+++ b/src/app/services/model-management.service.ts
@@ -326,18 +326,25 @@ export class ModelManagementService {
     if (!this.getTransformation(cellMapping)) {
       this.addValueTransformation(cellMapping);
     }
-    this.getTransformation(cellMapping) && this.getTransformation(cellMapping).setExpression(transformation);
+    if (this.getTransformation(cellMapping)) {
+      this.getTransformation(cellMapping).setExpression(transformation);
+    }
   }
 
   getTransformationLanguage(cellMapping: MappingBase): string {
     return this.getTransformation(cellMapping) && this.getTransformation(cellMapping).getLanguage();
   }
 
-  setTransformationLanguage(cellMapping: MappingBase, lang: string): void {
+  setTransformationLanguage(cellMapping: MappingBase, lang: string, expression: string): void {
     if (!this.getTransformation(cellMapping)) {
       this.addValueTransformation(cellMapping);
     }
-    this.getTransformation(cellMapping).setLanguage(lang);
+    if (!expression) {
+      cellMapping.setValueTransformation(undefined);
+    }
+    if (this.getTransformation(cellMapping)) {
+      this.getTransformation(cellMapping).setLanguage(lang);
+    }
   }
 
   addValueTransformation(cellMapping: MappingBase) {


### PR DESCRIPTION
KEEP THIS IN DRAFT AND DON'T MERGE: The reason is that the fix was actually based on wrong assumptions and breaks the empty prefix usage. The test and the steps can be used for the new implementation related with the empty prefix, then this can be deleted.


* When expression is removed the transformation language should be removed as well to keep the model valid.
* Add test