### PR TITLE
Gdb 4851 grel expression preview change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ testem.log
 Thumbs.db
 /cypress/screenshots/*
 /cypress/videos/*
-
+/cypress/logs/*

--- a/cypress/fixtures/edit-mapping/grel-expression-edit-mapping-model.json
+++ b/cypress/fixtures/edit-mapping/grel-expression-edit-mapping-model.json
@@ -1,0 +1,386 @@
+{
+  "columnModel": {
+    "columns": [
+      {
+        "cellIndex": 0,
+        "originalName": "color",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "color"
+      },
+      {
+        "cellIndex": 1,
+        "originalName": "director_name",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "director_name"
+      },
+      {
+        "cellIndex": 2,
+        "originalName": "num_critic_for_reviews",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "num_critic_for_reviews"
+      },
+      {
+        "cellIndex": 3,
+        "originalName": "duration",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "duration"
+      },
+      {
+        "cellIndex": 4,
+        "originalName": "director_facebook_likes",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "director_facebook_likes"
+      },
+      {
+        "cellIndex": 5,
+        "originalName": "actor_3_facebook_likes",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "actor_3_facebook_likes"
+      },
+      {
+        "cellIndex": 6,
+        "originalName": "actor_2_name",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "actor_2_name"
+      },
+      {
+        "cellIndex": 7,
+        "originalName": "actor_1_facebook_likes",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "actor_1_facebook_likes"
+      },
+      {
+        "cellIndex": 8,
+        "originalName": "gross",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "gross"
+      },
+      {
+        "cellIndex": 9,
+        "originalName": "genres",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "genres"
+      },
+      {
+        "cellIndex": 10,
+        "originalName": "actor_1_name",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "actor_1_name"
+      },
+      {
+        "cellIndex": 11,
+        "originalName": "movie_title",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "movie_title"
+      },
+      {
+        "cellIndex": 12,
+        "originalName": "num_voted_users",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "num_voted_users"
+      },
+      {
+        "cellIndex": 13,
+        "originalName": "cast_total_facebook_likes",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "cast_total_facebook_likes"
+      },
+      {
+        "cellIndex": 14,
+        "originalName": "actor_3_name",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "actor_3_name"
+      },
+      {
+        "cellIndex": 15,
+        "originalName": "facenumber_in_poster",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "facenumber_in_poster"
+      },
+      {
+        "cellIndex": 16,
+        "originalName": "plot_keywords",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "plot_keywords"
+      },
+      {
+        "cellIndex": 17,
+        "originalName": "movie_imdb_link",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "movie_imdb_link"
+      },
+      {
+        "cellIndex": 18,
+        "originalName": "num_user_for_reviews",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "num_user_for_reviews"
+      },
+      {
+        "cellIndex": 19,
+        "originalName": "language",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "language"
+      },
+      {
+        "cellIndex": 20,
+        "originalName": "country",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "country"
+      },
+      {
+        "cellIndex": 21,
+        "originalName": "content_rating",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "content_rating"
+      },
+      {
+        "cellIndex": 22,
+        "originalName": "budget",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "budget"
+      },
+      {
+        "cellIndex": 23,
+        "originalName": "title_year",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "title_year"
+      },
+      {
+        "cellIndex": 24,
+        "originalName": "actor_2_facebook_likes",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "actor_2_facebook_likes"
+      },
+      {
+        "cellIndex": 25,
+        "originalName": "imdb_score",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "imdb_score"
+      },
+      {
+        "cellIndex": 26,
+        "originalName": "aspect_ratio",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "aspect_ratio"
+      },
+      {
+        "cellIndex": 27,
+        "originalName": "movie_facebook_likes",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "movie_facebook_likes"
+      }
+    ],
+    "columnGroups": [],
+    "keyColumnName": "color",
+    "keyCellIndex": 0
+  },
+  "recordModel": {
+    "hasRecords": true
+  },
+  "overlayModels": {
+    "mappingDefinition": {
+      "mappingDefinition": {
+        "baseIRI": "http://example/base/",
+        "namespaces": {
+          "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        "subjectMappings": [
+          {
+            "subject": {
+              "valueSource": {
+                "source": "column",
+                "columnName": "duration"
+              }
+            },
+            "typeMappings": [],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "asa"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "123"
+                    },
+                    "valueType": {
+                      "type": "language_literal",
+                      "language": {
+                        "valueSource": {
+                          "source": "column",
+                          "columnName": "director_name"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "rdfSchema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "foaf",
+          "uri": "http://xmlns.com/foaf/0.1/"
+        }
+      ],
+      "baseUri": "http://localhost:3333/",
+      "rootNodes": []
+    }
+  },
+  "scripting": {
+    "grel": {
+      "name": "General Refine Expression Language (GREL)",
+      "defaultExpression": "value"
+    },
+    "clojure": {
+      "name": "Clojure",
+      "defaultExpression": "value"
+    }
+  },
+  "httpHeaders": {
+    "authorization": {
+      "header": "Authorization",
+      "defaultValue": ""
+    },
+    "user-agent": {
+      "header": "User-Agent",
+      "defaultValue": "OpenRefine 2.6 [1]"
+    },
+    "accept": {
+      "header": "Accept",
+      "defaultValue": "*/*"
+    }
+  }
+}

--- a/cypress/fixtures/en.json
+++ b/cypress/fixtures/en.json
@@ -81,7 +81,8 @@
     "CONFIRM_MAPPING_UPLOAD": "All mappings will be overwritten. Do you want to proceed?",
     "MAPPING_UPLOAD_ERROR": "Something went wrong.",
     "INCOMPLETE_MAPPING_ERROR": "The operation is not allowed. You have an incomplete mapping.",
-    "UNRECOGNIZED_PREFIX_ERROR": "Unrecognized prefix. "
+    "UNRECOGNIZED_PREFIX_ERROR": "Unrecognized prefix.",
+    "GREL_NO_PREVIEW": "No GREL preview"
   },
   "DIALOG": {
     "TITLE_CONFIRM": "Confirm",

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -4,3 +4,9 @@ module.exports = (on) =>
 {
   on('file:preprocessor', cypressTypeScriptPreprocessor);
 };
+
+module.exports = (on, config) => {
+  on('task', {
+    failed: require('cypress-failed-log/src/failed')(),
+  })
+};

--- a/cypress/steps/edit-dialog-steps.ts
+++ b/cypress/steps/edit-dialog-steps.ts
@@ -72,6 +72,17 @@ class EditDialogSteps {
   }
 
 
+  static selectSourceTypeColumn() {
+    return this.getTypeSection().find('[appCypressData=datatype-column]').click();
+  }
+
+  static completeSourceTypeColumn(value: string) {
+    return this.getTypeSection().find('[appCypressData=datatype-column-input]').should('be.visible')
+      .type(value + '{esc}', {
+        parseSpecialCharSequences: true
+      }).blur();
+  }
+
   // source section
   static getSourceSection() {
     return EditDialogSteps.getDialog().find('[appCypressData=source-section]');
@@ -102,6 +113,8 @@ class EditDialogSteps {
     return EditDialogSteps.getDialog().find('[appCypressData=transformation-section]');
   }
 
+  // Source GREL transformation
+
   static getTransformationExpressionField() {
     return this.getTransformationSection().find('[appCypressData=transformation-expression]');
   }
@@ -114,6 +127,20 @@ class EditDialogSteps {
     return this.getGrelTransformationButton().should('be.visible').click();
   }
 
+  static completeGREL(value: string) {
+    return this.getTransformationExpressionField().should('be.visible').type(value);
+  }
+
+  static clearGREL() {
+    return this.getTransformationExpressionField().should('be.visible').clear().blur();
+  }
+
+  static getGRELPreview() {
+    return cy.get('[appCypressData=expression-grel-preview]');
+  }
+
+  // Datatype GREL transformation
+
   static selectDataTypeGREL() {
     return this.getTypeSection().find('[appCypressData=datatype-transformation-grel]').should('be.visible').click();
   }
@@ -122,21 +149,49 @@ class EditDialogSteps {
     return this.getTypeSection().find('[appCypressData=datatype-transformation-prefix]').should('be.visible').click();
   }
 
-  static completeGREL(value: string) {
-    return this.getTransformationExpressionField().should('be.visible').type(value);
+  static getLanguageDataTypeGrelField() {
+    return this.getTypeSection().find('[appCypressData=datatype-transformation-expression]');
   }
 
   static completeDataTypeGREL(value: string) {
-    this.getTypeSection().find('[appCypressData=datatype-transformation-expression]').should('be.visible').type(value);
+    return this.getLanguageDataTypeGrelField().should('be.visible').type(value);
+  }
+
+  static getDataTypeGRELPreview() {
+    return cy.get('[appCypressData=datatype-grel-preview-content]');
+  }
+
+  static clearDataTypeGREL() {
+    return this.getLanguageDataTypeGrelField().should('be.visible').clear().blur();
+  }
+
+  // Language GREL transformation
+
+  static selectLanguageGREL() {
+    return this.getTypeSection().find('[appCypressData=language-transformation-grel]').should('be.visible').click();
+  }
+
+  static getLanguageTransformationExpressionField() {
+    return this.getTypeSection().find('[appCypressData=language-transformation-expression]');
+  }
+
+  static getLanguageGRELPreview() {
+    return cy.get('[appCypressData=language-grel-preview-content]');
   }
 
   static completeDataTypePrefix(value: string) {
     this.getTypeSection().find('[appCypressData=datatype-transformation-expression]').should('be.visible').type(value);
   }
 
-  static getGRELPreview() {
-    return this.getTransformationSection().find('[appCypressData=grel-preview]');
+  static completeLanguageGREL(value: string) {
+    return this.getLanguageTransformationExpressionField().should('be.visible').type(value);
   }
+
+  static clearLanguageGREL() {
+    return this.getLanguageTransformationExpressionField().should('be.visible').clear().blur();
+  }
+
+  // Prefix transformation
 
   static getPrefixTransformationButton() {
     return this.getTransformationSection().find(`[appCypressData=transformation-prefix]`);
@@ -157,10 +212,6 @@ class EditDialogSteps {
     return this.getTransformationExpressionField().should('be.visible').clear().type('{esc}', {
       parseSpecialCharSequences: true
     });
-  }
-
-  static getDataTypeGRELPreview() {
-    return this.getTypeSection().find('[appCypressData=datatype-grel-preview]');
   }
 
 }

--- a/cypress/steps/mapping-steps.ts
+++ b/cypress/steps/mapping-steps.ts
@@ -3,27 +3,48 @@
  */
 class MappingSteps {
 
+  /**
+   * Type the value string one character at a time with a bit of delay giving a chance to
+   * REST calls to complete: e.g. autocomplete
+   *
+   * @param value the string value to be completed in the field
+   * @param field the field where to type
+   */
+  static type(value: string, field: any) {
+    [...value].forEach((ch: any) => {
+      field.type(ch, {
+        delay: 100
+      });
+    });
+  }
+
   static completeTriple(index: number, subject?: string, predicate?: string, object?: string) {
     if (subject) {
-      MappingSteps.completeSubject(index , subject);
+      const field = MappingSteps.getTripleSubjectValue(index);
+      this.type(subject, field);
+      field.blur();
     }
     if (predicate) {
-      MappingSteps.completePredicate(index, predicate);
+      const field = MappingSteps.getTriplePredicateValue(index);
+      this.type(predicate, field);
+      field.blur();
     }
     if (object) {
-      MappingSteps.completeObject(index, object);
+      const field = MappingSteps.getTripleObjectValue(index);
+      this.type(object, field);
+      field.blur();
     }
   }
 
-  static completeSubject(index:number, value:string) {
+  static completeSubject(index: number, value: string) {
     MappingSteps.getTripleSubjectValue(index).type(value).blur();
   }
 
-  static completePredicate(index:number, value:string) {
+  static completePredicate(index: number, value: string) {
     MappingSteps.getTriplePredicateValue(index).type(value).blur();
   }
 
-  static completeObject(index:number, value:string) {
+  static completeObject(index: number, value: string) {
     MappingSteps.getTripleObjectValue(index).type(value).blur();
   }
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -26,6 +26,8 @@ import './viewport';
 // Import server and stubs
 import './server';
 
+import 'cypress-failed-log';
+
 // WORKAROUND FOR NAVIGATION CONFIRMATION
 // See https://github.com/cypress-io/cypress/issues/2938#issuecomment-549565158
 Cypress.on('window:before:load', function (window: any) {

--- a/cypress/test/edit-mapping.spec.ts
+++ b/cypress/test/edit-mapping.spec.ts
@@ -551,13 +551,11 @@ describe('Edit mapping', () => {
       HeaderSteps.getBothViewButton().click();
       // I see mapping preview
       MappingSteps.getTripleSubjectPreview(0).contains('<James%20Cameron>');
-      MappingSteps.getTripleObjectPreview(0).contains('person');
-      MappingSteps.getTriplePredicatePreview(1).contains('test');
+      MappingSteps.getTripleObjectPreview(0).contains('<person>');
+      MappingSteps.getTriplePredicatePreview(1).contains('<test>');
       MappingSteps.getTripleObjectPreview(1).contains('<http%3A%2F%2Fwww.imdb.com%2Ftitle%2Ftt0499549%2F%3Fref_%3Dfn_tt_tt_1>');
       // And I save the mapping
       HeaderSteps.saveMapping();
-      // Then I expect a loading indicator
-      HeaderSteps.getSaveIndicator().should('be.visible');
       // And The mapping should be saved
       cy.fixture('create-mapping/save-mapping-request-body').then((saveResponse: string) => {
         cy.wait('@saveMapping');

--- a/cypress/test/edit-mapping.spec.ts
+++ b/cypress/test/edit-mapping.spec.ts
@@ -333,6 +333,7 @@ describe('Edit mapping', () => {
       MappingSteps.getTriples().should('have.length', 2);
 
       // Verify source GREL transformation preview
+
       // When I open the subject edit dialog and focus on source GREL field
       MappingSteps.editTripleSubject(0);
       EditDialogSteps.selectGREL();
@@ -357,12 +358,22 @@ describe('Edit mapping', () => {
       // Then I expect error message to appear in the popover
       EditDialogSteps.getGRELPreview().find('[appCypressData=grel-preview]')
         .should('have.length', 1).first().should('contain', 'Parsing error at offset 6: Expecting something more at end of expression');
+      // When I complete a valid expression, close edit dialog and open it again
+      cy.wait('@loadGrelPreview');
+      mockPreview('["James Cameron","Gore Verbinski","Sam Mendes","Christopher Nolan"]');
       EditDialogSteps.clearGREL();
+      EditDialogSteps.completeGREL('value');
+      EditDialogSteps.saveConfiguration();
+      MappingSteps.editTripleSubject(0);
+      // Then I expect the grel preview to be properly loaded again
+      EditDialogSteps.getTransformationExpressionField().focus();
+      EditDialogSteps.getGRELPreview().find('[appCypressData=grel-preview]')
+        .should('have.length', 4).first().should('contain', 'James Cameron');
       EditDialogSteps.saveConfiguration();
 
       // Verify language GREL transformation preview
+
       // When I open the subject edit dialog and focus on language GREL field
-      cy.wait('@loadGrelPreview');
       mockPreview('[null]');
       MappingSteps.editTripleObjectWithData(0);
       EditDialogSteps.selectLanguageGREL();
@@ -388,9 +399,21 @@ describe('Edit mapping', () => {
       EditDialogSteps.getLanguageGRELPreview().find('[appCypressData=language-grel-preview]')
         .should('have.length', 1).first().should('contain', 'Parsing error at offset 6: Expecting something more at end of expression');
       EditDialogSteps.clearLanguageGREL();
+      // When I complete a valid expression, close edit dialog and open it again
+      cy.wait('@loadGrelPreview');
+      mockPreview('["James Cameron","Gore Verbinski","Sam Mendes","Christopher Nolan"]');
+      EditDialogSteps.clearLanguageGREL();
+      EditDialogSteps.completeLanguageGREL('value');
+      EditDialogSteps.saveConfiguration();
+      MappingSteps.editTripleObjectWithData(0);
+      // Then I expect the grel preview to be properly loaded again
+      EditDialogSteps.getLanguageTransformationExpressionField().focus();
+      EditDialogSteps.getLanguageGRELPreview().find('[appCypressData=language-grel-preview]')
+        .should('have.length', 4).first().should('contain', 'James Cameron');
       EditDialogSteps.saveConfiguration();
 
       // Verify datatype GREL transformation preview
+
       // When I open the subject edit dialog and focus on datatype GREL field
       mockPreview('[null]');
       MappingSteps.editTripleObjectWithData(0);
@@ -419,7 +442,17 @@ describe('Edit mapping', () => {
       // Then I expect error message to appear in the popover
       EditDialogSteps.getDataTypeGRELPreview().find('[appCypressData=datatype-grel-preview]')
         .should('have.length', 1).first().should('contain', 'Parsing error at offset 6: Expecting something more at end of expression');
+      // When I complete a valid expression, close edit dialog and open it again
+      cy.wait('@loadGrelPreview');
+      mockPreview('["James Cameron","Gore Verbinski","Sam Mendes","Christopher Nolan"]');
       EditDialogSteps.clearDataTypeGREL();
+      EditDialogSteps.completeDataTypeGREL('value');
+      EditDialogSteps.saveConfiguration();
+      MappingSteps.editTripleObjectWithData(0);
+      // Then I expect the grel preview to be properly loaded again
+      EditDialogSteps.getLanguageDataTypeGrelField().focus();
+      EditDialogSteps.getDataTypeGRELPreview().find('[appCypressData=datatype-grel-preview]')
+        .should('have.length', 4).first().should('contain', 'James Cameron');
       EditDialogSteps.saveConfiguration();
     });
   });

--- a/cypress/test/edit-mapping.spec.ts
+++ b/cypress/test/edit-mapping.spec.ts
@@ -8,6 +8,7 @@ describe('Edit mapping', () => {
     cy.setCookie('com.ontotext.graphdb.repository4200', 'Movies');
     cy.route('GET', '/sockjs-node/info?t=*', 'fixture:info.json');
     cy.route('GET', '/assets/i18n/en.json', 'fixture:en.json');
+    cy.route('POST', '/repositories/Movies', 'fixture:edit-mapping/autocomplete-response.json');
   });
 
   context('Edit IRI', () => {
@@ -66,7 +67,6 @@ describe('Edit mapping', () => {
     beforeEach(() => {
       cy.route('GET', '/orefine/command/core/get-models/?project=123', 'fixture:empty-mapping-model.json');
       cy.route('GET', '/repositories/Movies/namespaces', 'fixture:namespaces.json');
-      cy.route('POST', '/repositories/Movies', 'fixture:edit-mapping/autocomplete-response.json');
       cy.route('GET', '/rest/rdf-mapper/columns/ontorefine:123', 'fixture:columns.json').as('loadColumns');
       cy.visit('?dataProviderID=ontorefine:123');
       cy.wait('@loadColumns');
@@ -78,15 +78,15 @@ describe('Edit mapping', () => {
       MappingSteps.completeTriple(0, 'rdf:subject', 'rdf:@Title', 'rdf:$row_index');
       MappingSteps.getTripleSubjectPropertyTransformation(0).should('have.text', 'rdf');
       MappingSteps.getTripleSubjectSourceType(0).should('have.text', ' C ');
-      MappingSteps.getTripleSubjectSource(0).should('have.text', ' C  subject ')
+      MappingSteps.getTripleSubjectSource(0).should('have.text', ' C  subject ');
 
       MappingSteps.getTriplePredicatePropertyTransformation(0).should('have.text', 'rdf');
       MappingSteps.getTriplePredicateSourceType(0).should('have.text', ' @ ');
-      MappingSteps.getTriplePredicateValuePreview(0).should('have.text', ' @  Title ')
+      MappingSteps.getTriplePredicateValuePreview(0).should('have.text', ' @  Title ');
 
       MappingSteps.getTripleObjectPropertyTransformation(0).should('have.text', 'rdf');
       MappingSteps.getTripleObjectSourceType(0).should('have.text', ' $ ');
-      MappingSteps.getTripleObjectSource(0).should('have.text', ' $  row_index ')
+      MappingSteps.getTripleObjectSource(0).should('have.text', ' $  row_index ');
     });
 
     it('Should set extended prefix expressions', () => {
@@ -113,8 +113,6 @@ describe('Edit mapping', () => {
       MappingSteps.getNotification().should('be.visible').and('contain', 'Unrecognized prefix');
       MappingSteps.getNamespace('www').should('not.be.visible');
     });
-
-
   });
 
   // TODO: I add these tests here for now, but later we should distribute them in respective specs with the related operations
@@ -274,11 +272,11 @@ describe('Edit mapping', () => {
         method: 'POST',
         url: '/rest/rdf-mapper/grel/ontorefine:123?limit=10',
         status: 200,
-        response: response,
+        response,
         headers: {
           'Content-Type': 'application/json'
         }
-      });
+      }).as('loadGrelPreview');
     }
 
     it('Should preview empty object', () => {
@@ -312,6 +310,7 @@ describe('Edit mapping', () => {
       EditDialogSteps.selectGREL();
       EditDialogSteps.completeGREL('value');
       EditDialogSteps.getGRELPreview().first().should('contain', 'James Cameron');
+      EditDialogSteps.getTransformationExpressionField().blur();
 
       // Unfortunately cypress cannot return response based on POST data so mock twice the request
       mockPreview('["alabala"]');
@@ -323,8 +322,107 @@ describe('Edit mapping', () => {
       EditDialogSteps.completeDataTypeGREL('value');
       EditDialogSteps.getDataTypeGRELPreview().first().should('contain', 'alabala');
     });
-  });
 
+    it('Should show GREL preview in a popover', () => {
+      cy.route('GET', '/repositories/Movies/namespaces', 'fixture:namespaces.json');
+      cy.route('GET', '/rest/rdf-mapper/columns/ontorefine:123', 'fixture:columns.json');
+      cy.route('GET', '/orefine/command/core/get-models/?project=123', 'fixture:edit-mapping/grel-expression-edit-mapping-model.json');
+      mockPreview('[null]');
+      // Given I have created and loaded a mapping
+      cy.visit('?dataProviderID=ontorefine:123');
+      MappingSteps.getTriples().should('have.length', 2);
+
+      // Verify source GREL transformation preview
+      // When I open the subject edit dialog and focus on source GREL field
+      MappingSteps.editTripleSubject(0);
+      EditDialogSteps.selectGREL();
+      EditDialogSteps.getTransformationExpressionField().focus();
+      // Then I expect a preview popover to appear which contains no preview message
+      EditDialogSteps.getGRELPreview().first().should('contain', 'No GREL preview');
+      // When I type in the field
+      EditDialogSteps.completeGREL('v');
+      // Then I expect to see the no preview message
+      EditDialogSteps.getGRELPreview().first().should('contain', 'No GREL preview');
+      // When I complete a valid GREL
+      cy.wait('@loadGrelPreview');
+      mockPreview('["James Cameron","Gore Verbinski","Sam Mendes","Christopher Nolan"]');
+      EditDialogSteps.completeGREL('alue');
+      // Then I expect preview results to be rendered in the popover
+      EditDialogSteps.getGRELPreview().find('[appCypressData=grel-preview]')
+        .should('have.length', 4).first().should('contain', 'James Cameron');
+      // When There completed expression is invalid
+      cy.wait('@loadGrelPreview');
+      mockPreview('[{"error":"Parsing error at offset 6: Expecting something more at end of expression"},{"error":"Parsing error at offset 6: Expecting something more at end of expression"}]');
+      EditDialogSteps.completeGREL('+');
+      // Then I expect error message to appear in the popover
+      EditDialogSteps.getGRELPreview().find('[appCypressData=grel-preview]')
+        .should('have.length', 1).first().should('contain', 'Parsing error at offset 6: Expecting something more at end of expression');
+      EditDialogSteps.clearGREL();
+      EditDialogSteps.saveConfiguration();
+
+      // Verify language GREL transformation preview
+      // When I open the subject edit dialog and focus on language GREL field
+      cy.wait('@loadGrelPreview');
+      mockPreview('[null]');
+      MappingSteps.editTripleObjectWithData(0);
+      EditDialogSteps.selectLanguageGREL();
+      EditDialogSteps.getLanguageTransformationExpressionField().focus();
+      // Then I expect a preview popover to appear which contains no preview message
+      EditDialogSteps.getLanguageGRELPreview().first().should('contain', 'No GREL preview');
+      // When I type in the field
+      EditDialogSteps.completeLanguageGREL('v');
+      // Then I expect to see the no preview message
+      EditDialogSteps.getLanguageGRELPreview().first().should('contain', 'No GREL preview');
+      // When I complete a valid GREL
+      cy.wait('@loadGrelPreview');
+      mockPreview('["James Cameron","Gore Verbinski","Sam Mendes","Christopher Nolan"]');
+      EditDialogSteps.completeLanguageGREL('alue');
+      // Then I expect preview results to be rendered in the popover
+      EditDialogSteps.getLanguageGRELPreview().find('[appCypressData=language-grel-preview]')
+        .should('have.length', 4).first().should('contain', 'James Cameron');
+      // When There completed expression is invalid
+      cy.wait('@loadGrelPreview');
+      mockPreview('[{"error":"Parsing error at offset 6: Expecting something more at end of expression"},{"error":"Parsing error at offset 6: Expecting something more at end of expression"}]');
+      EditDialogSteps.completeLanguageGREL('+');
+      // Then I expect error message to appear in the popover
+      EditDialogSteps.getLanguageGRELPreview().find('[appCypressData=language-grel-preview]')
+        .should('have.length', 1).first().should('contain', 'Parsing error at offset 6: Expecting something more at end of expression');
+      EditDialogSteps.clearLanguageGREL();
+      EditDialogSteps.saveConfiguration();
+
+      // Verify datatype GREL transformation preview
+      // When I open the subject edit dialog and focus on datatype GREL field
+      mockPreview('[null]');
+      MappingSteps.editTripleObjectWithData(0);
+      EditDialogSteps.selectTypeDataTypeLiteral();
+      EditDialogSteps.selectSourceTypeColumn();
+      EditDialogSteps.completeSourceTypeColumn('director_name');
+      EditDialogSteps.selectDataTypeGREL();
+      EditDialogSteps.getLanguageDataTypeGrelField().focus();
+      // Then I expect a preview popover to appear which contains no preview message
+      EditDialogSteps.getDataTypeGRELPreview().first().should('contain', 'No GREL preview');
+      // When I type in the field
+      EditDialogSteps.completeDataTypeGREL('v');
+      // Then I expect to see the no preview message
+      EditDialogSteps.getDataTypeGRELPreview().first().should('contain', 'No GREL preview');
+      // When I complete a valid GREL
+      cy.wait('@loadGrelPreview');
+      mockPreview('["James Cameron","Gore Verbinski","Sam Mendes","Christopher Nolan"]');
+      EditDialogSteps.completeDataTypeGREL('alue');
+      // Then I expect preview results to be rendered in the popover
+      EditDialogSteps.getDataTypeGRELPreview().find('[appCypressData=datatype-grel-preview]')
+        .should('have.length', 4).first().should('contain', 'James Cameron');
+      // When There completed expression is invalid
+      cy.wait('@loadGrelPreview');
+      mockPreview('[{"error":"Parsing error at offset 6: Expecting something more at end of expression"},{"error":"Parsing error at offset 6: Expecting something more at end of expression"}]');
+      EditDialogSteps.completeDataTypeGREL('+');
+      // Then I expect error message to appear in the popover
+      EditDialogSteps.getDataTypeGRELPreview().find('[appCypressData=datatype-grel-preview]')
+        .should('have.length', 1).first().should('contain', 'Parsing error at offset 6: Expecting something more at end of expression');
+      EditDialogSteps.clearDataTypeGREL();
+      EditDialogSteps.saveConfiguration();
+    });
+  });
 
   context('incomplete mapping', () => {
     it('Should not allow operations with incomplete mapping', () => {
@@ -379,18 +477,18 @@ describe('Edit mapping', () => {
       // When I load application
       cy.visit('?dataProviderID=ontorefine:123');
       // I switch to preview mode
-      HeaderSteps.getPreviewButton().click()
+      HeaderSteps.getPreviewButton().click();
 
-      //WHEN
-      //I delete the object
+      // WHEN
+      // I delete the object
       MappingSteps.deleteTripleObject(0);
       MappingSteps.confirm();
 
-      //THEN
+      // THEN
       // Subject and predicate are in preview mode
       MappingSteps.getTripleSubject(0).should('contain', '<James%20Cameron>');
       MappingSteps.getTriplePredicate(0).should('contain', '<test>');
-      MappingSteps.getTripleObject(0).should('have.length',1);
+      MappingSteps.getTripleObject(0).should('have.length', 1);
     });
   });
 
@@ -442,5 +540,5 @@ describe('Edit mapping', () => {
 
 function assertNotAllowedNotification() {
   MappingSteps.getNotification().should('contain', 'The operation is not allowed. You have an incomplete mapping.');
-  MappingSteps.getNotification().should('not.be.visible')
+  MappingSteps.getNotification().should('not.be.visible');
 }

--- a/cypress/test/main/amsterdam-mapping.spec.ts
+++ b/cypress/test/main/amsterdam-mapping.spec.ts
@@ -12,7 +12,20 @@ describe('Create Amsterdam restaurants mapping', () => {
     cy.route('GET', '/orefine/command/core/get-models/?project=123', 'fixture:amsterdam/amsterdam-model.json');
   });
 
+  function mockPreview(response: string) {
+    cy.route({
+      method: 'POST',
+      url: '/rest/rdf-mapper/grel/ontorefine:123?limit=10',
+      status: 200,
+      response,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }).as('loadGrelPreview');
+  }
+
   it('Should be able to create Amsterdam restaurants mapping', () => {
+    mockPreview('[null]');
     // When I load application
     cy.visit('?dataProviderID=ontorefine:123');
     cy.wait('@loadColumns');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5741,6 +5741,16 @@
         }
       }
     },
+    "cypress-failed-log": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cypress-failed-log/-/cypress-failed-log-2.7.0.tgz",
+      "integrity": "sha512-9tSuFRjlAGZuH+IIiyDM7IAvjh4dmet/iUPLRxet9ugLkELw/cyW7jUCQmR7j4aW8Fl+ZlbNUekVonBaS322SA==",
+      "dev": true,
+      "requires": {
+        "debug": "4.1.1",
+        "logdown": "3.3.1"
+      }
+    },
     "cypress-file-upload": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-4.0.7.tgz",
@@ -11956,6 +11966,15 @@
             "strip-ansi": "^4.0.0"
           }
         }
+      }
+    },
+    "logdown": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/logdown/-/logdown-3.3.1.tgz",
+      "integrity": "sha512-pjX0vlIJsYQlgVzFba2amXI1wZZnhrEorL68MdLI7B0/sN1TNUozBNFaHfcPHMM3A+INZ0OXFDxtnoaEgOmGjQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0"
       }
     },
     "loglevel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,9 +252,9 @@
       "integrity": "sha512-7Pp7aqNNcH4fu1BnOVpvqJJHjE7RZ5K1oD396OWCh35pgpLowLSpFjhbVhzGrcAuxHyKnnHSX3etLn2hDaHxmQ=="
     },
     "@angular/cdk": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-9.2.3.tgz",
-      "integrity": "sha512-tQr/yt8GNGsZ/DTT+PMq7XdRmL56hwVCyf8F12JQAawutSLfTfMb+S1lpN7L/0Pb/L5JBuCfG2HmXK7vHo02gw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-9.2.4.tgz",
+      "integrity": "sha512-iw2+qHMXHYVC6K/fttHeNHIieSKiTEodVutZoOEcBu9rmRTGbLB26V/CRsfIRmA1RBk+uFYWc6UQZnMC3RdnJQ==",
       "requires": {
         "parse5": "^5.0.0"
       },
@@ -2721,6 +2721,21 @@
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
           }
+        }
+      }
+    },
+    "@ncstate/sat-popover": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ncstate/sat-popover/-/sat-popover-6.0.0.tgz",
+      "integrity": "sha512-1Pkc4byY0asc1SgPxwSQKPZ7wJwUIZdwW8HH5htNhqCpDmVmihOJblCYRpnbLraWMhYSz1Ym9btucrnB8FBD+Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/Ontotext-AD/mapping-ui#readme",
   "dependencies": {
     "@angular/animations": "^9.1.6",
-    "@angular/cdk": "^9.2.3",
+    "@angular/cdk": "^9.2.4",
     "@angular/common": "^9.1.6",
     "@angular/compiler": "^9.1.6",
     "@angular/core": "^9.1.6",
@@ -48,6 +48,7 @@
     "@angular/platform-browser": "^9.1.6",
     "@angular/platform-browser-dynamic": "^9.1.6",
     "@angular/router": "^9.1.6",
+    "@ncstate/sat-popover": "^6.0.0",
     "@ngx-translate/core": "^12.1.2",
     "@ngx-translate/http-loader": "^4.0.0",
     "@w11k/ngx-componentdestroyed": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@typescript-eslint/parser": "^3.0.1",
     "codelyzer": "^5.1.2",
     "cypress": "^4.5.0",
+    "cypress-failed-log": "^2.7.0",
     "cypress-file-upload": "^4.0.7",
     "eslint": "^7.0.0",
     "eslint-config-google": "^0.14.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,7 @@ import {DirectivesModule} from 'src/app/directives/directives.module';
 import {environment} from 'src/environments/environment';
 import {ComponentsModule} from 'src/app/main/components/components.module';
 import {TokenInterceptor} from './auth/token.interceptor';
+import {SatPopoverModule} from '@ncstate/sat-popover';
 
 export function HttpLoaderFactory(httpClient: HttpClient) {
   return new TranslateHttpLoader(httpClient, environment.httpLoaderPrefix, environment.httpLoaderSuffix);
@@ -52,6 +53,7 @@ export function HttpLoaderFactory(httpClient: HttpClient) {
     MatSnackBarModule,
     FormsModule,
     DirectivesModule,
+    SatPopoverModule,
   ],
   providers: [TranslateService, {
     provide: HTTP_INTERCEPTORS,

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
@@ -136,7 +136,8 @@
                   </mat-icon>
                 </mat-form-field>
 
-                <sat-popover #expressionGrelPreview verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
+                <sat-popover #expressionGrelPreview (opened)="onExpressionGrelPreviewOpen()"
+                             verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
                   <mat-card class="grel-preview-content" appCypressData="expression-grel-preview">
                     <mat-card-content *ngIf="(grelPreviewExpression | async)">
                       <div *ngFor="let preview of grelPreviewExpression | async; let index = index;" appCypressData="grel-preview">
@@ -258,7 +259,8 @@
                       </mat-icon>
                     </mat-form-field>
 
-                    <sat-popover #datatypeGrelPreview verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
+                    <sat-popover #datatypeGrelPreview (opened)="onDataTypeGrelPreviewOpen()"
+                                 verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
                       <mat-card class="grel-preview-content" appCypressData="datatype-grel-preview-content">
                         <mat-card-content *ngIf="(grelPreviewDataTypeTransformation | async)">
                           <div *ngFor="let preview of grelPreviewDataTypeTransformation | async; let index = index;" appCypressData="datatype-grel-preview">
@@ -372,7 +374,8 @@
                       </mat-icon>
                     </mat-form-field>
 
-                    <sat-popover #languageGrelPreview verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
+                    <sat-popover #languageGrelPreview (opened)="onLanguageGrelPreviewOpen()"
+                                 verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
                       <mat-card class="grel-preview-content" appCypressData="language-grel-preview-content">
                         <mat-card-content *ngIf="(grelPreviewLanguageTransformation | async)">
                           <div *ngFor="let preview of grelPreviewLanguageTransformation | async; let index = index;" appCypressData="language-grel-preview">

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
@@ -110,11 +110,18 @@
               <div fxLayout="column" fxLayoutAlign="space-around stretch">
                 <mat-form-field class="ml-16">
                   <mat-label>{{'LABELS.EXPRESSION' | translate}}</mat-label>
-                  <textarea matInput formControlName="expression" name="expression"
+                  <textarea matInput formControlName="expression" name="expression" *ngIf="isPrefixTransformation"
                             cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
                             [matAutocomplete]="prefixAuto"
                             [placeholder]="!isPrefixTransformation ? ('LABELS.GREL_PLACEHOLDER' | translate) : ''"
                             appCypressData="transformation-expression"></textarea>
+                  <textarea matInput formControlName="expression" name="expression" *ngIf="!isPrefixTransformation"
+                            cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
+                            [matAutocomplete]="prefixAuto"
+                            [placeholder]="!isPrefixTransformation ? ('LABELS.GREL_PLACEHOLDER' | translate) : ''"
+                            appCypressData="transformation-expression"
+                            [satPopoverAnchor]='expressionGrelPreview'
+                            (focus)="expressionGrelPreview.open()" (blur)="expressionGrelPreview.close()"></textarea>
                   <mat-autocomplete #prefixAuto="matAutocomplete">
                     <div *ngIf="isPrefixTransformation">
                       <mat-option *ngFor="let namespace of filteredNamespaces | async" [value]="namespace.prefix + ':'">
@@ -129,17 +136,20 @@
                   </mat-icon>
                 </mat-form-field>
 
-                <div class="ml-16" *ngIf="!isPrefixTransformation">
-                  <div
-                    *ngFor="let preview of grelPreviewExpression | async; let index = index;" appCypressData="grel-preview">
-                    <div class="mb-2 cursor-pointer" *ngIf="preview"
-                         [ngClass]="{hide: index !== 0 && !showTransformation}"
-                         (click)="showTransformation = !showTransformation"
-                         matTooltip="{{showTransformation ? ('TOOLTIPS.CLICK_TO_HIDE' | translate) : ('TOOLTIPS.CLICK_FOR_MORE' | translate)}}">
-                      {{preview.error || preview}}
-                    </div>
-                  </div>
-                </div>
+                <sat-popover #expressionGrelPreview verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
+                  <mat-card class="grel-preview-content" appCypressData="expression-grel-preview">
+                    <mat-card-content *ngIf="(grelPreviewExpression | async)">
+                      <div *ngFor="let preview of grelPreviewExpression | async; let index = index;" appCypressData="grel-preview">
+                        <div class="mb-2" *ngIf="preview">
+                          {{preview.error || preview}}
+                        </div>
+                      </div>
+                    </mat-card-content>
+                    <mat-card-content *ngIf="!(grelPreviewExpression | async)">
+                      {{'MESSAGES.GREL_NO_PREVIEW' | translate}}
+                    </mat-card-content>
+                  </mat-card>
+                </sat-popover>
               </div>
             </div>
           </div>
@@ -222,11 +232,18 @@
                   <div fxLayout="column" fxLayoutAlign="space-around stretch">
                     <mat-form-field class="ml-16">
                       <mat-label>{{'LABELS.EXPRESSION' | translate}}</mat-label>
-                      <textarea matInput formControlName="datatypeTransformation" name="datatypeTransformation"
+                      <textarea matInput formControlName="datatypeTransformation" name="datatypeTransformation" *ngIf="isDataTypePrefixTransformation"
                                 cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
                                 [matAutocomplete]="datatypePrefixAuto"
                                 [placeholder]="!isDataTypePrefixTransformation ? ('LABELS.GREL_PLACEHOLDER' | translate) : ''"
                                 appCypressData="datatype-transformation-expression"></textarea>
+                      <textarea matInput formControlName="datatypeTransformation" name="datatypeTransformation" *ngIf="!isDataTypePrefixTransformation"
+                                cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
+                                [matAutocomplete]="datatypePrefixAuto"
+                                [placeholder]="!isDataTypePrefixTransformation ? ('LABELS.GREL_PLACEHOLDER' | translate) : ''"
+                                appCypressData="datatype-transformation-expression"
+                                [satPopoverAnchor]='datatypeGrelPreview'
+                                (focus)="datatypeGrelPreview.open()" (blur)="datatypeGrelPreview.close()"></textarea>
                       <mat-autocomplete #datatypePrefixAuto="matAutocomplete">
                         <div *ngIf="isDataTypePrefixTransformation">
                           <mat-option *ngFor="let namespace of filteredNamespaces | async" [value]="namespace.prefix + ':'">
@@ -241,17 +258,20 @@
                       </mat-icon>
                     </mat-form-field>
 
-                    <div class="ml-16" *ngIf="!isDataTypePrefixTransformation">
-                      <div
-                        *ngFor="let preview of grelPreviewDataTypeTransformation | async; let index = index;" appCypressData="datatype-grel-preview">
-                        <div class="mb-2 cursor-pointer" *ngIf="preview"
-                             [ngClass]="{hide: index !== 0 && !showDataTypeTransformation}"
-                             (click)="showDataTypeTransformation = !showDataTypeTransformation"
-                             matTooltip="{{showDataTypeTransformation ? ('TOOLTIPS.CLICK_TO_HIDE' | translate) : ('TOOLTIPS.CLICK_FOR_MORE' | translate)}}">
-                          {{preview.error || preview}}
-                        </div>
-                      </div>
-                    </div>
+                    <sat-popover #datatypeGrelPreview verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
+                      <mat-card class="grel-preview-content" appCypressData="datatype-grel-preview-content">
+                        <mat-card-content *ngIf="(grelPreviewDataTypeTransformation | async)">
+                          <div *ngFor="let preview of grelPreviewDataTypeTransformation | async; let index = index;" appCypressData="datatype-grel-preview">
+                            <div class="mb-2" *ngIf="preview">
+                              {{preview.error || preview}}
+                            </div>
+                          </div>
+                        </mat-card-content>
+                        <mat-card-content *ngIf="!(grelPreviewDataTypeTransformation | async)">
+                          {{'MESSAGES.GREL_NO_PREVIEW' | translate}}
+                        </mat-card-content>
+                      </mat-card>
+                    </sat-popover>
                   </div>
                 </div>
               </div>
@@ -326,11 +346,18 @@
                   <div fxLayout="column" fxLayoutAlign="space-around stretch">
                     <mat-form-field class="ml-16">
                       <mat-label>{{'LABELS.EXPRESSION' | translate}}</mat-label>
-                      <textarea matInput formControlName="languageTransformation" name="languageTransformation"
+                      <textarea matInput formControlName="languageTransformation" name="languageTransformation" *ngIf="isLanguagePrefixTransformation"
                                 cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
                                 [matAutocomplete]="languagePrefixAuto"
                                 [placeholder]="!isLanguagePrefixTransformation ? ('LABELS.GREL_PLACEHOLDER' | translate) : ''"
                                 appCypressData="language-transformation-expression"></textarea>
+                      <textarea matInput formControlName="languageTransformation" name="languageTransformation" *ngIf="!isLanguagePrefixTransformation"
+                                cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
+                                [matAutocomplete]="languagePrefixAuto"
+                                [placeholder]="!isLanguagePrefixTransformation ? ('LABELS.GREL_PLACEHOLDER' | translate) : ''"
+                                appCypressData="language-transformation-expression"
+                                [satPopoverAnchor]='languageGrelPreview'
+                                (focus)="languageGrelPreview.open()" (blur)="languageGrelPreview.close()"></textarea>
                       <mat-autocomplete #languagePrefixAuto="matAutocomplete">
                         <div *ngIf="isLanguagePrefixTransformation">
                           <mat-option *ngFor="let namespace of filteredNamespaces | async" [value]="namespace.prefix + ':'">
@@ -345,17 +372,20 @@
                       </mat-icon>
                     </mat-form-field>
 
-                    <div class="ml-16" *ngIf="!isLanguagePrefixTransformation">
-                      <div
-                        *ngFor="let preview of grelPreviewLanguageTransformation | async; let index = index;">
-                        <div class="mb-2 cursor-pointer" *ngIf="preview"
-                             [ngClass]="{hide: index !== 0 && !showLanguageTransformation}"
-                             (click)="showLanguageTransformation = !showLanguageTransformation"
-                             matTooltip="{{showLanguageTransformation ? ('TOOLTIPS.CLICK_TO_HIDE' | translate) : ('TOOLTIPS.CLICK_FOR_MORE' | translate)}}">
-                          {{preview.error || preview}}
-                        </div>
-                      </div>
-                    </div>
+                    <sat-popover #languageGrelPreview verticalAlign="below" horizontalAlign="start" [autoFocus]="false" [restoreFocus]="false">
+                      <mat-card class="grel-preview-content" appCypressData="language-grel-preview-content">
+                        <mat-card-content *ngIf="(grelPreviewLanguageTransformation | async)">
+                          <div *ngFor="let preview of grelPreviewLanguageTransformation | async; let index = index;" appCypressData="language-grel-preview">
+                            <div class="mb-2" *ngIf="preview">
+                              {{preview.error || preview}}
+                            </div>
+                          </div>
+                        </mat-card-content>
+                        <mat-card-content *ngIf="!(grelPreviewLanguageTransformation | async)">
+                          {{'MESSAGES.GREL_NO_PREVIEW' | translate}}
+                        </mat-card-content>
+                      </mat-card>
+                    </sat-popover>
                   </div>
                 </div>
               </div>

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.scss
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.scss
@@ -4,6 +4,11 @@
   }
 }
 
+.grel-preview-content {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
 div.hide{
   display: none;
 }

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.spec.ts
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.spec.ts
@@ -20,7 +20,8 @@ import {MatInputModule} from "@angular/material/input";
 import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {MatSlideToggleModule} from "@angular/material/slide-toggle";
 import {MatDividerModule} from "@angular/material/divider";
-
+import {SatPopoverModule} from '@ncstate/sat-popover';
+import {MatCardModule} from '@angular/material/card';
 
 
 describe('MapperDialogComponent', () => {
@@ -58,6 +59,8 @@ describe('MapperDialogComponent', () => {
         BrowserAnimationsModule,
         MatSlideToggleModule,
         MatDividerModule,
+        SatPopoverModule,
+        MatCardModule,
       ],
       providers: [
         TranslateService,

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
@@ -406,6 +406,8 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
         .subscribe((value) => {
           if (value && !this.isPrefixTransformation) {
             this.grelPreviewExpression = this.previewGREL(value);
+          } else {
+            this.grelPreviewExpression = EMPTY;
           }
         });
 
@@ -414,6 +416,8 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
         .subscribe((value) => {
           if (value && !this.isLanguagePrefixTransformation) {
             this.grelPreviewLanguageTransformation = this.previewLanguageGREL(value);
+          } else {
+            this.grelPreviewLanguageTransformation = EMPTY;
           }
         });
 
@@ -423,6 +427,8 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
           if (value && !this.isDataTypePrefixTransformation) {
             this.grelPreviewDataTypeTransformation = this.previewDataTypeGREL(value);
             this.firstGrelPreviewDataTypeTransformation = this.grelPreviewDataTypeTransformation[0];
+          } else {
+            this.grelPreviewDataTypeTransformation = EMPTY;
           }
         });
 
@@ -465,14 +471,15 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
       return EMPTY;
     }
     return this.mapperService.previewGREL(valueSource, value)
-        .pipe(untilComponentDestroyed(this), map((value) => {
-          const errors = value.map((e) => (e && e.error) ? e.error : e)
+        .pipe(untilComponentDestroyed(this), map((response) => {
+          const errors = response.map((e) => (e && e.error) ? e.error : e)
               .filter((val, index, self) => self.indexOf(val) === index);
           // Do not show the same error multiple times if it is the same for all results
           if (errors.length === 1) {
-            return errors;
+            // there might be an element with null value
+            return errors[0] !== null && errors;
           }
-          return value;
+          return response;
         }));
   }
 

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
@@ -77,9 +77,6 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
   firstGrelPreviewDataTypeTransformation: any;
   title: string;
   hasChildren: boolean;
-  showDataTypeTransformation = false;
-  showLanguageTransformation = false;
-  showTransformation = false;
 
   constructor(public dialogRef: MatDialogRef<MapperDialogComponent>,
               @Inject(MAT_DIALOG_DATA) public data: SubjectMapperData,
@@ -103,6 +100,21 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
     this.subscribeToValueChanges();
 
     this.subscribeToCheckDirty();
+  }
+
+  public onExpressionGrelPreviewOpen() {
+    const expressionValue = this.mapperForm.get('expression').value;
+    this.resolveGrelExpressionPreview(expressionValue);
+  }
+
+  public onLanguageGrelPreviewOpen() {
+    const languageTransformation = this.mapperForm.get('languageTransformation').value;
+    this.resolveGrelLanguagePreview(languageTransformation);
+  }
+
+  public onDataTypeGrelPreviewOpen() {
+    const datatypeTransformation = this.mapperForm.get('datatypeTransformation').value;
+    this.resolveGrelDataTypePreview(datatypeTransformation);
   }
 
   private setDialogStyle() {
@@ -284,6 +296,31 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
     this.isPrefixTransformation = this.isTransformation && this.mappingDetails.language === Language.Prefix;
   }
 
+  private resolveGrelExpressionPreview(value?: string) {
+    if (value && !this.isPrefixTransformation) {
+      this.grelPreviewExpression = this.previewGREL(value);
+    } else {
+      this.grelPreviewExpression = EMPTY;
+    }
+  }
+
+  private resolveGrelLanguagePreview(value?: string) {
+    if (value && !this.isLanguagePrefixTransformation) {
+      this.grelPreviewLanguageTransformation = this.previewLanguageGREL(value);
+    } else {
+      this.grelPreviewLanguageTransformation = EMPTY;
+    }
+  }
+
+  private resolveGrelDataTypePreview(value?: string) {
+    if (value && !this.isDataTypePrefixTransformation) {
+      this.grelPreviewDataTypeTransformation = this.previewDataTypeGREL(value);
+      this.firstGrelPreviewDataTypeTransformation = this.grelPreviewDataTypeTransformation[0];
+    } else {
+      this.grelPreviewDataTypeTransformation = EMPTY;
+    }
+  }
+
   private subscribeToValueChanges() {
     this.mapperForm.get('typeMapping').valueChanges
         .pipe(untilComponentDestroyed(this))
@@ -404,32 +441,19 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
     this.mapperForm.get('expression').valueChanges
         .pipe(untilComponentDestroyed(this))
         .subscribe((value) => {
-          if (value && !this.isPrefixTransformation) {
-            this.grelPreviewExpression = this.previewGREL(value);
-          } else {
-            this.grelPreviewExpression = EMPTY;
-          }
+          this.resolveGrelExpressionPreview(value);
         });
 
     this.mapperForm.get('languageTransformation').valueChanges
         .pipe(untilComponentDestroyed(this))
         .subscribe((value) => {
-          if (value && !this.isLanguagePrefixTransformation) {
-            this.grelPreviewLanguageTransformation = this.previewLanguageGREL(value);
-          } else {
-            this.grelPreviewLanguageTransformation = EMPTY;
-          }
+          this.resolveGrelLanguagePreview(value);
         });
 
     this.mapperForm.get('datatypeTransformation').valueChanges
         .pipe(untilComponentDestroyed(this))
         .subscribe((value) => {
-          if (value && !this.isDataTypePrefixTransformation) {
-            this.grelPreviewDataTypeTransformation = this.previewDataTypeGREL(value);
-            this.firstGrelPreviewDataTypeTransformation = this.grelPreviewDataTypeTransformation[0];
-          } else {
-            this.grelPreviewDataTypeTransformation = EMPTY;
-          }
+          this.resolveGrelDataTypePreview(value);
         });
 
     this.filteredNamespaces = merge(this.mapperForm.get('expression').valueChanges, this.mapperForm.get('datatypeTransformation').valueChanges, this.mapperForm.get('languageTransformation').valueChanges)

--- a/src/app/main/mapper/mapper.module.ts
+++ b/src/app/main/mapper/mapper.module.ts
@@ -26,7 +26,8 @@ import {MatDividerModule} from '@angular/material/divider';
 import {CellModule} from 'src/app/main/mapper/cell/cell.module';
 import {ModelManagementService} from 'src/app/services/model-management.service';
 import {JSONValueDialog} from 'src/app/main/mapper/json-value-dialog';
-
+import {SatPopoverModule} from '@ncstate/sat-popover';
+import {MatCardModule} from '@angular/material/card';
 
 @NgModule({
   declarations: [
@@ -67,6 +68,8 @@ import {JSONValueDialog} from 'src/app/main/mapper/json-value-dialog';
     MatSlideToggleModule,
     MatButtonToggleModule,
     MatDividerModule,
+    SatPopoverModule,
+    MatCardModule,
   ],
   providers: [ModelManagementService],
 })

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -81,7 +81,8 @@
     "CONFIRM_MAPPING_UPLOAD": "All mappings will be overwritten. Do you want to proceed?",
     "MAPPING_UPLOAD_ERROR": "Something went wrong.",
     "INCOMPLETE_MAPPING_ERROR": "The operation is not allowed. You have an incomplete mapping.",
-    "UNRECOGNIZED_PREFIX_ERROR": "Unrecognized prefix. "
+    "UNRECOGNIZED_PREFIX_ERROR": "Unrecognized prefix.",
+    "GREL_NO_PREVIEW": "No GREL preview"
   },
   "DIALOG": {
     "TITLE_CONFIRM": "Confirm",


### PR DESCRIPTION
* Integrated external popover component and used it to render the grel expression preview when the field is focused.
* Integrate the popover for all GREL expression fields.
* Add tests.

Additional: Installed the cypress-failed-logs plugin in order to have more detailed logs for the failed tests

Resolves:
https://ontotext.atlassian.net/browse/GDB-4851
https://ontotext.atlassian.net/browse/GDB-4738
https://ontotext.atlassian.net/browse/GDB-4794