### PR TITLE
GDB-4661 add missed tooltips

### DIFF
--- a/cypress/fixtures/en.json
+++ b/cypress/fixtures/en.json
@@ -8,6 +8,7 @@
     "SAVE": "Save",
     "PREVIEW": "Preview",
     "OK": "Ok",
+    "CANCEL": "Cancel",
     "CONFIGURATION": "Configuration",
     "PREVIEW_AND_CONFIGURATION": "Both",
     "UPLOAD_JSON": "Upload JSON"
@@ -28,6 +29,7 @@
     "OPEN_PREVIEW": "Open mapping preview",
     "NEW_MAPPING": "Create new mapping",
     "SAVE_AND_CLOSE": "Save and close configuration",
+    "CANCEL_EDIT": "Cancel edit operation",
     "GREL_VALUE_HELP": "Open value type documentation in separate window",
     "CLICK_FOR_MORE": "Click for more examples",
     "CLICK_TO_HIDE": "Click to hide examples",

--- a/cypress/fixtures/en.json
+++ b/cypress/fixtures/en.json
@@ -31,7 +31,10 @@
     "GREL_VALUE_HELP": "Open value type documentation in separate window",
     "CLICK_FOR_MORE": "Click for more examples",
     "CLICK_TO_HIDE": "Click to hide examples",
-    "UPLOAD_JSON": "Click to upload JSON mapping"
+    "UPLOAD_JSON": "Click to upload JSON mapping",
+    "VIEW_MODE_CONFIGURATION": "Enable mapping configuration mode. Only configuration data will be visible.",
+    "VIEW_MODE_PREVIEW": "Enable mapping preview mode. Only data preview will be visible.",
+    "VIEW_MODE_BOTH": "Enable mapping mixed config and preview mode. Both data preview and configurations will be visible."
   },
   "LABELS": {
     "RDF_VALUE": "RDF value",

--- a/src/app/main/mapper/header/header.component.html
+++ b/src/app/main/mapper/header/header.component.html
@@ -1,8 +1,8 @@
 <div fxLayout="row" fxLayoutAlign="end end" appCypressData="header" class="header-component py-2">
   <mat-button-toggle-group class="mr-auto" value="{{ViewMode.Configuration}}" (change)="togglePreview($event)">
-    <mat-button-toggle value="{{ViewMode.Configuration}}" appCypressData="view-configuration-button">{{"BUTTONS.CONFIGURATION" | translate}}</mat-button-toggle>
-    <mat-button-toggle value="{{ViewMode.Preview}}" appCypressData="view-preview-button">{{"BUTTONS.PREVIEW" | translate}}</mat-button-toggle>
-    <mat-button-toggle value="{{ViewMode.PreviewAndConfiguration}}" appCypressData="view-both-button">{{"BUTTONS.PREVIEW_AND_CONFIGURATION" | translate}}</mat-button-toggle>
+    <mat-button-toggle value="{{ViewMode.Configuration}}" appCypressData="view-configuration-button" matTooltip="{{'TOOLTIPS.VIEW_MODE_CONFIGURATION' | translate}}">{{"BUTTONS.CONFIGURATION" | translate}}</mat-button-toggle>
+    <mat-button-toggle value="{{ViewMode.Preview}}" appCypressData="view-preview-button" matTooltip="{{'TOOLTIPS.VIEW_MODE_PREVIEW' | translate}}">{{"BUTTONS.PREVIEW" | translate}}</mat-button-toggle>
+    <mat-button-toggle value="{{ViewMode.PreviewAndConfiguration}}" appCypressData="view-both-button" matTooltip="{{'TOOLTIPS.VIEW_MODE_BOTH' | translate}}">{{"BUTTONS.PREVIEW_AND_CONFIGURATION" | translate}}</mat-button-toggle>
   </mat-button-toggle-group>
 
   <span class="mr-12 unsaved-changes-msg">

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
@@ -365,14 +365,14 @@
       </div>
 
       <mat-divider class="mt-24"></mat-divider>
-      <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end none" class="mb-24">
-        <button class="btn-primary" [mat-dialog-close]="data" (click)="save()" [disabled]="isMappingInvalid()"
-                matTooltip="{{'TOOLTIPS.SAVE_AND_CLOSE' | translate}}" appCypressData="ok-mapping-button">
-          {{'BUTTONS.OK' | translate}}
-        </button>
+      <div mat-dialog-actions fxLayout="row" fxLayoutAlign="end none" class="mb-6">
+        <button class="btn mr-2" appCypressData="cancel-mapping-button" mat-dialog-close matTooltip="{{'TOOLTIPS.CANCEL_EDIT' | translate}}">{{'BUTTONS.CANCEL' | translate}}</button>
+        <span matTooltip="{{'TOOLTIPS.SAVE_AND_CLOSE' | translate}}">
+          <button class="btn btn-primary" [mat-dialog-close]="data" (click)="save()" [disabled]="isMappingInvalid()" appCypressData="ok-mapping-button">
+            {{'BUTTONS.OK' | translate}}
+          </button>
+        </span>
       </div>
     </form>
   </div>
-
-
 </div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -8,6 +8,7 @@
     "SAVE": "Save",
     "PREVIEW": "Preview",
     "OK": "Ok",
+    "CANCEL": "Cancel",
     "CONFIGURATION": "Configuration",
     "PREVIEW_AND_CONFIGURATION": "Both",
     "UPLOAD_JSON": "Upload JSON"
@@ -28,6 +29,7 @@
     "OPEN_PREVIEW": "Open mapping preview",
     "NEW_MAPPING": "Create new mapping",
     "SAVE_AND_CLOSE": "Save and close configuration",
+    "CANCEL_EDIT": "Cancel edit operation",
     "GREL_VALUE_HELP": "Open value type documentation in separate window",
     "CLICK_FOR_MORE": "Click for more examples",
     "CLICK_TO_HIDE": "Click to hide examples",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -31,7 +31,10 @@
     "GREL_VALUE_HELP": "Open value type documentation in separate window",
     "CLICK_FOR_MORE": "Click for more examples",
     "CLICK_TO_HIDE": "Click to hide examples",
-    "UPLOAD_JSON": "Click to upload JSON mapping"
+    "UPLOAD_JSON": "Click to upload JSON mapping",
+    "VIEW_MODE_CONFIGURATION": "Enable mapping configuration mode. Only configuration data will be visible.",
+    "VIEW_MODE_PREVIEW": "Enable mapping preview mode. Only data preview will be visible.",
+    "VIEW_MODE_BOTH": "Enable mapping mixed config and preview mode. Both data preview and configurations will be visible."
   },
   "LABELS": {
     "RDF_VALUE": "RDF value",


### PR DESCRIPTION
* Add tooltips on the view mode buttons
* Add cancel button with label and tooltip in the edit dialog
* Show tooltip for the OK button in the edit dialog when the form is invalid. It didn't show up until now because the button was disabled in that case which prevented the tooltip triggering.
* Buttons OK/Cancel in the edit dialog are now properly styled

https://ontotext.atlassian.net/browse/GDB-4661