### PR TITLE
GDB-4860 warn users when autocomplete is off

### DIFF
--- a/cypress/fixtures/en.json
+++ b/cypress/fixtures/en.json
@@ -84,7 +84,8 @@
     "MAPPING_UPLOAD_ERROR": "Something went wrong.",
     "INCOMPLETE_MAPPING_ERROR": "The operation is not allowed. You have an incomplete mapping.",
     "UNRECOGNIZED_PREFIX_ERROR": "Unrecognized prefix.",
-    "GREL_NO_PREVIEW": "No GREL preview"
+    "GREL_NO_PREVIEW": "No GREL preview",
+    "AUTOCOMPLETE_OFF_WARNING": "Autocomplete is OFF. Go to Setup -> Autocomplete"
   },
   "DIALOG": {
     "TITLE_CONFIRM": "Confirm",

--- a/cypress/test/autocomplete.spec.ts
+++ b/cypress/test/autocomplete.spec.ts
@@ -1,6 +1,4 @@
 import MappingSteps from '../steps/mapping-steps';
-import HeaderSteps from '../steps/header-steps';
-import EditDialogSteps from '../steps/edit-dialog-steps';
 
 describe('Autocomplete mapping', () => {
 
@@ -12,6 +10,7 @@ describe('Autocomplete mapping', () => {
     cy.route('GET', '/repositories/Movies/namespaces', 'fixture:namespaces.json');
     cy.route('POST', '/repositories/Movies', 'fixture:edit-mapping/autocomplete-response.json');
     cy.route('GET', '/rest/rdf-mapper/columns/ontorefine:123', 'fixture:columns.json').as('loadColumns');
+    cy.route('GET', '/rest/autocomplete/enabled', 'true');
     cy.visit('?dataProviderID=ontorefine:123');
   });
 

--- a/cypress/test/autocomplete.spec.ts
+++ b/cypress/test/autocomplete.spec.ts
@@ -1,4 +1,5 @@
 import MappingSteps from '../steps/mapping-steps';
+import EditDialogSteps from '../steps/edit-dialog-steps';
 
 describe('Autocomplete mapping', () => {
 

--- a/cypress/test/edit-mapping.spec.ts
+++ b/cypress/test/edit-mapping.spec.ts
@@ -9,6 +9,7 @@ describe('Edit mapping', () => {
     cy.route('GET', '/sockjs-node/info?t=*', 'fixture:info.json');
     cy.route('GET', '/assets/i18n/en.json', 'fixture:en.json');
     cy.route('POST', '/repositories/Movies', 'fixture:edit-mapping/autocomplete-response.json');
+    cy.route('GET', '/rest/autocomplete/enabled', 'true');
   });
 
   context('Edit IRI', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import {Component} from '@angular/core';
 import {TranslateService} from '@ngx-translate/core';
 import 'reflect-metadata';
+import {AutocompleteService} from './services/rest/autocomplete.service';
 
 @Component({
   selector: 'app-root',
@@ -8,8 +9,9 @@ import 'reflect-metadata';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
-  constructor(public translate: TranslateService) {
+  constructor(public translate: TranslateService, private autocompleteService: AutocompleteService) {
     this.initTranslation();
+    this.autocompleteService.autocompleteStatus().subscribe();
   }
 
   private initTranslation() {

--- a/src/app/main/mapper/cell/empty-block/empty-block.component.ts
+++ b/src/app/main/mapper/cell/empty-block/empty-block.component.ts
@@ -150,7 +150,7 @@ export class EmptyBlockComponent extends OnDestroyMixin implements OnInit, After
     this.suggestions = merge(this.autoInput.valueChanges)
         .pipe(untilComponentDestroyed(this),
             map((value) => {
-              const valueStr = value as String;
+              const valueStr = value as string;
               if (valueStr.indexOf(SOURCE_SIGN.Column) >= 0) {
                 return of(this.sources.filter((source) => source.title.toLowerCase().includes(value.toLowerCase().substr(valueStr.indexOf(SOURCE_SIGN.Column) + 1)))
                     .map((source) => {
@@ -189,7 +189,6 @@ export class EmptyBlockComponent extends OnDestroyMixin implements OnInit, After
       this.saveInputValue(emitTab);
     }
   }
-
 
   public saveInputValue(emitTab: boolean) {
     let value = this.autoInput.value;

--- a/src/app/services/cookies.service.ts
+++ b/src/app/services/cookies.service.ts
@@ -1,0 +1,15 @@
+import {Injectable} from '@angular/core';
+import {CookieService} from 'ngx-cookie-service';
+import {RestService} from './rest/rest.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CookiesService {
+  constructor(protected cookies: CookieService) {
+  }
+
+  getRepositoryCookie() {
+    return this.cookies.get('com.ontotext.graphdb.repository' + RestService.getPort());
+  }
+}

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -37,19 +37,30 @@ export class NotificationService {
     });
   }
 
+  public warning(message) {
+    this.zone.run(() => {
+      this.snackBar.open(message, 'action', this.getWarningSnackConfig());
+    });
+  }
+
   public error(message) {
     this.zone.run(() => {
       this.snackBar.open(message, 'action', this.getErrorSnackConfig());
     });
   }
 
-  private getErrorSnackConfig() {
-    const errorConfig = {panelClass: 'error-notification'};
-    return {...this.config, ...errorConfig};
-  }
-
   private getSuccessSnackConfig() {
     const successConfig = {panelClass: 'success-notification'};
     return {...this.config, ...successConfig};
+  }
+
+  private getWarningSnackConfig() {
+    const warningConfig = {panelClass: 'warning-notification'};
+    return {...this.config, ...warningConfig};
+  }
+
+  private getErrorSnackConfig() {
+    const errorConfig = {panelClass: 'error-notification'};
+    return {...this.config, ...errorConfig};
   }
 }

--- a/src/app/services/rest/autocomplete.service.ts
+++ b/src/app/services/rest/autocomplete.service.ts
@@ -1,0 +1,57 @@
+import {Injectable} from '@angular/core';
+import {ErrorReporterService} from '../error-reporter.service';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {catchError} from 'rxjs/operators';
+import {environment} from 'src/environments/environment';
+import {CookiesService} from '../cookies.service';
+import {map} from 'rxjs/internal/operators';
+import {NotificationService} from '../notification.service';
+import {TranslateService} from '@ngx-translate/core';
+
+/**
+ * This is a stateful service which maintains an autocomplete enabled flag. The service method
+ * {@link autocompleteStatus} must be called during the application bootstrap or periodically
+ * retried if it's needed to keep the status in sync.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AutocompleteService {
+  private apiUrl = environment.autocompleteApiUrl;
+  private autocompleteEnabled = false;
+  private autocompleteWarningDisplayed = false;
+
+  constructor(private httpClient: HttpClient,
+              private cookiesService: CookiesService,
+              private translateService: TranslateService,
+              private notificationService: NotificationService,
+              private errorReporterService: ErrorReporterService) {
+  }
+
+  autocompleteStatus(): Observable<boolean> {
+    const httpHeaders = new HttpHeaders({
+      'X-GraphDB-Repository': this.cookiesService.getRepositoryCookie(),
+    });
+    const httpOptions = {headers: httpHeaders};
+
+    return this.httpClient.get<boolean>(`${this.apiUrl}/enabled`, httpOptions).pipe(map(
+        (status) => this.setAutocompleteStatus(status),
+        catchError((error) => this.errorReporterService.handleError('Autocomplete status check failed.', error)),
+    ));
+  }
+
+  isAustocompleteEnabled(): boolean {
+    if (!this.autocompleteEnabled && !this.autocompleteWarningDisplayed) {
+      const message = this.translateService.instant('MESSAGES.AUTOCOMPLETE_OFF_WARNING');
+      this.notificationService.warning(message);
+      this.autocompleteWarningDisplayed = true;
+    }
+    return this.autocompleteEnabled;
+  }
+
+  private setAutocompleteStatus(status: boolean) {
+    this.autocompleteEnabled = status;
+    return status;
+  }
+}

--- a/src/app/services/rest/mapper.service.spec.ts
+++ b/src/app/services/rest/mapper.service.spec.ts
@@ -3,8 +3,7 @@ import {TestBed} from '@angular/core/testing';
 import {MapperService} from './mapper.service';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {ErrorReporterService} from '../error-reporter.service';
-import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 
 describe('MapperService', () => {
   let service: MapperService;

--- a/src/app/services/rest/repository.service.spec.ts
+++ b/src/app/services/rest/repository.service.spec.ts
@@ -4,7 +4,7 @@ import { RepositoryService } from './repository.service';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {RouterTestingModule} from '@angular/router/testing';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
-
+import {TranslateModule} from '@ngx-translate/core';
 
 describe('RepositoryService', () => {
   let service: RepositoryService;
@@ -15,6 +15,7 @@ describe('RepositoryService', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         MatSnackBarModule,
+        TranslateModule.forRoot(),
       ]
     });
     service = TestBed.inject(RepositoryService);

--- a/src/app/services/rest/repository.service.ts
+++ b/src/app/services/rest/repository.service.ts
@@ -7,7 +7,6 @@ import {ErrorReporterService} from '../error-reporter.service';
 import {AutocompleteService} from './autocomplete.service';
 import {CookiesService} from '../cookies.service';
 import {SPARQL_AUTOCOMPLETE, SPARQL_IRI_DESCRIPTION, SPARQL_PREDICATES, SPARQL_TYPES} from '../../utils/constants';
-import {RestService} from './rest.service';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/services/rest/rest.service.ts
+++ b/src/app/services/rest/rest.service.ts
@@ -26,7 +26,6 @@ export class RestService {
     headers: this.httpHeaders,
   };
 
-
   static getPort() {
     let port = window.location.port;
     if (!port) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -84,7 +84,8 @@
     "MAPPING_UPLOAD_ERROR": "Something went wrong.",
     "INCOMPLETE_MAPPING_ERROR": "The operation is not allowed. You have an incomplete mapping.",
     "UNRECOGNIZED_PREFIX_ERROR": "Unrecognized prefix.",
-    "GREL_NO_PREVIEW": "No GREL preview"
+    "GREL_NO_PREVIEW": "No GREL preview",
+    "AUTOCOMPLETE_OFF_WARNING": "Autocomplete is OFF. Go to Setup -> Autocomplete"
   },
   "DIALOG": {
     "TITLE_CONFIRM": "Confirm",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,6 +3,7 @@ export const environment = {
   restApiUrl: '/rest/rdf-mapper',
   mappingApiUrl: '/orefine/command',
   repositoryApiUrl: '/repositories',
+  autocompleteApiUrl: '/rest/autocomplete',
   httpLoaderPrefix: './assets/i18n/',
   httpLoaderSuffix: '.js',
   openRefineVariables: 'https://github.com/OpenRefine/OpenRefine/wiki/Variables',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,6 +7,7 @@ export const environment = {
   restApiUrl: 'http://localhost:7200/rest/rdf-mapper',
   mappingApiUrl: 'http://localhost:7200/orefine/command',
   repositoryApiUrl: 'http://localhost:7200/repositories',
+  autocompleteApiUrl: 'http://localhost:7200/rest/autocomplete',
   httpLoaderPrefix: './assets/i18n/',
   httpLoaderSuffix: '.json',
   openRefineVariables: 'https://github.com/OpenRefine/OpenRefine/wiki/Variables',

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -238,6 +238,9 @@ $altTheme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
 .mat-snack-bar-container.error-notification {
   background-color: #ed4f2f;
 }
+.mat-snack-bar-container.warning-notification {
+  background-color: #c4781e;
+}
 .mat-snack-bar-container.success-notification {
   background-color: #5cb85c;
 }


### PR DESCRIPTION
Obtain the autocomplete status during the application bootstrap and maintain it in the autocomplete service. When the autocomplete is used for the first time, check the status and warn the user if autocomplete is disabled.

* Implemented autocomplete service
* Extracted a cookies service
* Extended the notification service with a warning method

https://ontotext.atlassian.net/browse/GDB-4860