### PR TITLE
GDB-4897 open/close edit dialog with key combinations

### DIFF
--- a/cypress/steps/edit-dialog-steps.ts
+++ b/cypress/steps/edit-dialog-steps.ts
@@ -9,6 +9,10 @@ class EditDialogSteps {
     return cy.cypressData(MapperComponentSelectors.MAPPER_DIALOG_SELECTOR);
   }
 
+  static getDialogTitle() {
+    return this.getDialog().find('[appCypressData="dialog-title"]');
+  }
+
   static getOkButton() {
     return EditDialogSteps.getDialog().find(`[appCypressData=${MapperComponentSelectors.OK_MAPPING_BUTTON_SELECTOR}]`);
   }

--- a/src/app/main/mapper/cell/empty-block/empty-block.component.html
+++ b/src/app/main/mapper/cell/empty-block/empty-block.component.html
@@ -12,6 +12,7 @@
                  [matAutocomplete]="autocInline"
                  (keydown.tab)="saveInputValue(false)"
                  (keydown.enter)="selectPrefixOrValue(true)"
+                 (keydown.control.Enter)="onEdit()"
                  (blur)="saveInputValueOnBlur($event)">
           <mat-autocomplete #autocInline="matAutocomplete" (optionSelected)="selectPrefixOrValue(true)" #tooltip="matTooltip"  [matTooltip]="optionTooltip" appCypressData="autocomplete-tooltip">
             <mat-option appCypressData="cell-option" *ngFor="let option of suggestions | async | async" [value]="(autoInput.value.endsWith('@') || autoInput.value.endsWith('$')) ? autoInput.value.slice(0, -1) + option.value : option.value"

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
@@ -539,6 +539,10 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
           if (event.key === 'Escape' || event.key === 'Esc') {
             this.checkDirty();
           }
+          if (event.ctrlKey && event.keyCode === 13 && !this.isMappingInvalid()) {
+            this.dialogRef.close();
+            this.save();
+          }
         });
   }
 


### PR DESCRIPTION
* Open edit dialog with ctrl+enter while mapping cell is focused
* Close the edit dialog with ctrl+enter if the form is changed and valid and the focus is not in a text input field

https://ontotext.atlassian.net/browse/GDB-4897