### PR TITLE
GDB-4933 properly create empty mapping when need

### DIFF
--- a/src/app/main/mapper/mapper.component.ts
+++ b/src/app/main/mapper/mapper.component.ts
@@ -26,7 +26,7 @@ import {NamespaceValidator} from '../../validators/namespace.validator';
 })
 export class MapperComponent extends OnDestroyMixin implements OnInit {
   sources: Array<Source>;
-  mapping: MappingDefinitionImpl = plainToClass(MappingDefinitionImpl, EMPTY_MAPPING);
+  mapping: MappingDefinitionImpl = plainToClass(MappingDefinitionImpl, MapperComponent.createNewMapping());
   rdfMapping: BehaviorSubject<{mapping: MappingDefinitionImpl, isDirty: boolean}>;
   rdf: string;
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
@@ -41,6 +41,12 @@ export class MapperComponent extends OnDestroyMixin implements OnInit {
               private translateService: TranslateService,
               private namespaceValidator: NamespaceValidator) {
     super();
+  }
+
+  static createNewMapping() {
+    const newMapping = EMPTY_MAPPING;
+    newMapping.subjectMappings = [];
+    return newMapping;
   }
 
   ngOnInit(): void {
@@ -65,7 +71,7 @@ export class MapperComponent extends OnDestroyMixin implements OnInit {
         .pipe(untilComponentDestroyed(this))
         .subscribe(() => {
           const payload = {
-            mapping: new MappingDefinitionImpl(EMPTY_MAPPING.baseIRI, EMPTY_MAPPING.namespaces, EMPTY_MAPPING.subjectMappings),
+            mapping: new MappingDefinitionImpl(EMPTY_MAPPING.baseIRI, EMPTY_MAPPING.namespaces, []),
             isDirty: false,
           };
           this.rdfMapping.next(payload);

--- a/src/app/services/rest/mapping-definition.service.ts
+++ b/src/app/services/rest/mapping-definition.service.ts
@@ -6,7 +6,7 @@ import {HttpClient, HttpParams} from '@angular/common/http';
 import {ActivatedRoute} from '@angular/router';
 import {Observable, of, EMPTY} from 'rxjs';
 import {map, switchMap, catchError} from 'rxjs/operators';
-import {EMPTY_MAPPING} from 'src/app/utils/constants';
+import {EMPTY_MAPPING} from '../../utils/constants';
 
 @Injectable({
   providedIn: 'root',
@@ -17,6 +17,12 @@ export class MappingDefinitionService extends RestService {
               private errorReporterService: ErrorReporterService) {
     super(route);
     this.apiUrl = environment.mappingApiUrl;
+  }
+
+  static createNewMapping() {
+    const newMapping = EMPTY_MAPPING;
+    newMapping.subjectMappings = [];
+    return newMapping;
   }
 
   getAPIURL(apiName: string): Observable<string> {
@@ -33,7 +39,7 @@ export class MappingDefinitionService extends RestService {
     return this.getAPIURL('/core/get-models/').pipe(switchMap((fullUrl) => {
       return this.httpClient.get<JSON>(fullUrl, this.httpOptions).pipe(map((json) => {
         if (!json['overlayModels']['mappingDefinition']) {
-          return EMPTY_MAPPING;
+          return MappingDefinitionService.createNewMapping();
         }
         return json['overlayModels']['mappingDefinition']['mappingDefinition'];
       }), catchError((error) => this.errorReporterService.handleError('Loading model failed.', error)));


### PR DESCRIPTION
The `EMPTY_MAPPING` constant contains a `subjectMappings` property which is an array. When its used once and any mapping is created it remains untouched because the array reference is never cleared.

https://ontotext.atlassian.net/browse/GDB-4933