### PR TITLE
GDB-4901 Improve table cell config visual representation

### DIFF
--- a/cypress/steps/mapping-steps.ts
+++ b/cypress/steps/mapping-steps.ts
@@ -223,8 +223,8 @@ class MappingSteps {
     return MappingSteps.getTripleObject(index).find('.valuetransformation .ti-transform');
   }
 
-  static getTripleObjectDatatypeTransformation(index: any) {
-    return MappingSteps.getTripleObject(index).find('.datatypetransformation .ti-transform');
+  static getTripleObjectSecondaryType(index: any) {
+    return MappingSteps.getTripleObject(index).find('.datatypetransformation .ti-type');
   }
 
   static deleteTripleObject(index: number) {

--- a/cypress/test/apply-prefixes.spec.ts
+++ b/cypress/test/apply-prefixes.spec.ts
@@ -116,15 +116,15 @@ describe('Apply prefixes', () => {
       MappingSteps.getTriples().should('have.length', 1);
       // And I have created a subject, a predicate and an object
       MappingSteps.completeTriple(0, 'rdf:subject', 'rdf:@Title', 'rdf:$row_index');
-      MappingSteps.getTripleSubjectPropertyTransformation(0).should('have.text', 'rdf');
+      MappingSteps.getTripleSubjectPropertyTransformation(0).should('have.text', 'rdf:');
       MappingSteps.getTripleSubjectSourceType(0).should('have.text', ' C ');
       MappingSteps.getTripleSubjectSource(0).should('have.text', ' C  subject ');
 
-      MappingSteps.getTriplePredicatePropertyTransformation(0).should('have.text', 'rdf');
+      MappingSteps.getTriplePredicatePropertyTransformation(0).should('have.text', 'rdf:');
       MappingSteps.getTriplePredicateSourceType(0).should('have.text', ' @ ');
       MappingSteps.getTriplePredicateValuePreview(0).should('have.text', ' @  Title ');
 
-      MappingSteps.getTripleObjectPropertyTransformation(0).should('have.text', 'rdf');
+      MappingSteps.getTripleObjectPropertyTransformation(0).should('have.text', 'rdf:');
       MappingSteps.getTripleObjectSourceType(0).should('have.text', ' $ ');
       MappingSteps.getTripleObjectSource(0).should('have.text', ' $  row_index ');
     });

--- a/cypress/test/autocomplete.spec.ts
+++ b/cypress/test/autocomplete.spec.ts
@@ -24,7 +24,7 @@ describe('Autocomplete mapping', () => {
       MappingSteps.getSuggestions(0).first().should('contain', 'wgs:').click();
       MappingSteps.type('test', () => MappingSteps.getTripleObjectValue(0));
       MappingSteps.getTripleObjectValue(0).blur();
-      MappingSteps.getTripleObjectPropertyTransformation(0).should('have.text', 'wgs');
+      MappingSteps.getTripleObjectPropertyTransformation(0).should('have.text', 'wgs:');
       MappingSteps.getTripleObjectSource(0).should('have.text', ' C  test ');
     });
 
@@ -34,7 +34,7 @@ describe('Autocomplete mapping', () => {
       MappingSteps.type('rdf:@', () => MappingSteps.getTripleObjectValue(0));
       MappingSteps.getSuggestions(0).should('have.length', 28);
       MappingSteps.getSuggestions(0).first().should('contain', 'color').click();
-      MappingSteps.getTripleObjectPropertyTransformation(0).should('have.text', 'rdf');
+      MappingSteps.getTripleObjectPropertyTransformation(0).should('have.text', 'rdf:');
       MappingSteps.getTripleObjectSource(0).should('have.text', ' @  color ');
       // When I type on the subject position an extended prefix plus column beginning
       MappingSteps.type('rdf:ext@du', () => MappingSteps.getTripleSubjectValue(1));

--- a/cypress/test/create-mapping.spec.ts
+++ b/cypress/test/create-mapping.spec.ts
@@ -157,7 +157,7 @@ describe('Create mapping', () => {
       // And I expect object to have a prefix, grel and datatype transformation badge
       MappingSteps.getTripleObjectPropertyTransformation(0).should('contain', 'GREL');
       MappingSteps.getTripleObjectValueTransformation(0).should('contain', 'rdf');
-      MappingSteps.getTripleObjectDatatypeTransformation(0).should('contain', 'Datatype');
+      MappingSteps.getTripleObjectSecondaryType(0).should('contain', 'Datatype');
       // Second triple
       // Then I expect subject to have a property prefix badge
       MappingSteps.getTripleSubjectPropertyTransformation(1).should('contain', 'GREL');
@@ -166,7 +166,7 @@ describe('Create mapping', () => {
       // And I expect object to have a prefix, grel and datatype transformation badge
       MappingSteps.getTripleObjectPropertyTransformation(1).should('contain', 'GREL');
       MappingSteps.getTripleObjectValueTransformation(1).should('contain', 'GREL');
-      MappingSteps.getTripleObjectDatatypeTransformation(1).should('contain', 'Language');
+      MappingSteps.getTripleObjectSecondaryType(1).should('contain', 'Language');
     });
 
     it('Should not be able to set prefix transformation when type is not IRI', () => {
@@ -193,7 +193,7 @@ describe('Create mapping', () => {
       EditDialogSteps.completePrefix('rdf');
       EditDialogSteps.saveConfiguration();
       // Then I should see the prefix in the object cell
-      MappingSteps.getTripleObjectPropertyTransformation(0).should('contain', 'rdf');
+      MappingSteps.getTripleObjectPropertyTransformation(0).should('contain', 'rdf:');
       // When I open the object edit dialog
       MappingSteps.editTripleObjectWithData(0);
       // Then I expect the prefix still to be selected and completed

--- a/cypress/test/edit-mapping.spec.ts
+++ b/cypress/test/edit-mapping.spec.ts
@@ -642,9 +642,9 @@ describe('Edit mapping', () => {
       MappingSteps.completeTriple(0, 'sub', 'rdf:type', 'obj');
       // THEN
       // It is a type mapping triple
-      MappingSteps.getTripleSubject(0).should('have.text', ' C  sub IRI');
-      MappingSteps.getTriplePredicate(0).should('have.text', 'aIRI');
-      MappingSteps.getTripleObject(0).should('have.text', ' C  obj IRI');
+      MappingSteps.getTripleSubject(0).should('have.text', ' C  sub <IRI>');
+      MappingSteps.getTriplePredicate(0).should('have.text', 'a<IRI>');
+      MappingSteps.getTripleObject(0).should('have.text', ' C  obj <IRI>');
     });
 
     it('Should treat rdf:type as type mapping predicate in the edit mapping dialog', () => {
@@ -665,7 +665,7 @@ describe('Edit mapping', () => {
 
       // THEN
       // It is a type mapping triple
-      MappingSteps.getTriplePredicate(0).should('have.text', 'aIRI');
+      MappingSteps.getTriplePredicate(0).should('have.text', 'a<IRI>');
     });
   });
 });

--- a/src/app/main/mapper/cell/cell.component.ts
+++ b/src/app/main/mapper/cell/cell.component.ts
@@ -115,6 +115,16 @@ export class CellComponent extends OnDestroyMixin implements OnInit {
   }
 
   /**
+   * Get the secondary (language or datatype) transformation for the cell
+   *
+   * @return value transornmation
+   */
+  getSecondaryTransformation(): ValueTransformationImpl {
+    return this.modelManagementService.getValueTypeDatatypeTransformation((this.cellMapping)) ||
+      this.modelManagementService.getValueTypeLanguageTransformation((this.cellMapping));
+  }
+
+  /**
    * Get value Type. Returns the ValueType but only when the cellMapping is a ValueMapping
    * Only ValueMappings have such a type
    *
@@ -223,6 +233,10 @@ export class CellComponent extends OnDestroyMixin implements OnInit {
 
   public onEdit() {
     this.onEditClick.emit();
+  }
+
+  isGRELTransformation(transformation: ValueTransformationImpl) {
+    return transformation && transformation.getLanguage() === 'grel';
   }
 
   getReasonableLongWord(word: string) {

--- a/src/app/main/mapper/cell/configuration-and-preview-cell/configuration-and-preview-cell.component.html
+++ b/src/app/main/mapper/cell/configuration-and-preview-cell/configuration-and-preview-cell.component.html
@@ -31,8 +31,7 @@
             <div fxFlex="auto">
               <app-transformation-type-badge [cellMapping]="cellMapping" [target]="propertytransformation"></app-transformation-type-badge>
             </div>
-
-            <div class="ml-8" fxFlex="grow">
+            <div *ngIf="!isGRELTransformation(getTransformation())" fxFlex="grow">
              <span class="ti-source">
                 <span *ngIf="getSourceType() === 'column'" matTooltip="{{getValueSource().getColumnName()}}">
                   <span class="ti-source-type type-col" title="column">
@@ -57,6 +56,12 @@
               </span>
             </div>
 
+            <div *ngIf="isGRELTransformation(getTransformation())" class="ml-2" fxFlex="grow">
+             <span class="ti-source" matTooltip="{{getTransformation().getExpression()}}">
+               {{getReasonableLongWord(getTransformation().getExpression())}}
+              </span>
+            </div>
+
             <app-type-badge [type]="getType()"></app-type-badge>
           </div>
 
@@ -65,7 +70,7 @@
               <app-transformation-type-badge [cellMapping]="cellMapping" [target]="valuetransformation"></app-transformation-type-badge>
             </div>
 
-            <div class="ml-8" fxFlex="grow">
+            <div fxFlex="grow" *ngIf="!isGRELTransformation(getSecondaryTransformation())">
               <span class="ti-source">
                 <div *ngIf="getDatatypeSource()">
                   <span *ngIf="getDatatypeSourceType() === 'column'"
@@ -117,6 +122,12 @@
                     {{getValueTypeLanguageSource().source}}
                   </span>
                 </div>
+              </span>
+            </div>
+
+            <div *ngIf="isGRELTransformation(getSecondaryTransformation())" class="ml-2" fxFlex="grow">
+             <span class="ti-source" matTooltip="{{getSecondaryTransformation().getExpression()}}">
+               {{getReasonableLongWord(getSecondaryTransformation().getExpression())}}
               </span>
             </div>
 

--- a/src/app/main/mapper/cell/configuration-cell/configuration-cell.component.html
+++ b/src/app/main/mapper/cell/configuration-cell/configuration-cell.component.html
@@ -31,7 +31,7 @@
               <app-transformation-type-badge [cellMapping]="cellMapping" [target]="propertytransformation"></app-transformation-type-badge>
             </div>
 
-            <div class="ml-8" fxFlex="grow">
+            <div *ngIf="!(isGRELTransformation(getTransformation()))" fxFlex="grow">
              <span class="ti-source">
                 <span *ngIf="getSourceType() === 'column'" matTooltip="{{getValueSource().getColumnName()}}">
                   <span class="ti-source-type type-col" title="column">
@@ -56,6 +56,14 @@
               </span>
             </div>
 
+            <div *ngIf="isGRELTransformation(getTransformation())" class="ml-2" fxFlex="grow">
+             <span class="ti-source" matTooltip="{{getTransformation().getExpression()}}">
+               {{getReasonableLongWord(getTransformation().getExpression())}}
+              </span>
+            </div>
+
+
+
             <app-type-badge [type]="getType()"></app-type-badge>
           </div>
 
@@ -64,7 +72,7 @@
               <app-transformation-type-badge [cellMapping]="cellMapping" [target]="valuetransformation"></app-transformation-type-badge>
             </div>
 
-            <div class="ml-8" fxFlex="grow">
+            <div fxFlex="grow" *ngIf="!(isGRELTransformation(getSecondaryTransformation()))">
               <span class="ti-source">
                 <div *ngIf="getDatatypeSource()">
                   <span *ngIf="getDatatypeSourceType() === 'column'"
@@ -116,6 +124,12 @@
                     {{getValueTypeLanguageSource().source}}
                   </span>
                 </div>
+              </span>
+            </div>
+
+            <div *ngIf="isGRELTransformation(getSecondaryTransformation())" class="ml-2" fxFlex="grow">
+             <span class="ti-source" matTooltip="{{getSecondaryTransformation().getExpression()}}">
+               {{getReasonableLongWord(getSecondaryTransformation().getExpression())}}
               </span>
             </div>
 

--- a/src/app/main/mapper/cell/transformation-type-badge/transformation-type-badge.component.html
+++ b/src/app/main/mapper/cell/transformation-type-badge/transformation-type-badge.component.html
@@ -1,3 +1,3 @@
 <div *ngIf="rendered()" [ngClass]="target">
-  <span class="ti-transform" [ngClass]="getCssClass()">{{getLabel()}}</span>
+  <span [ngClass]="getCssClass()">{{getLabel()}}</span>
 </div>

--- a/src/app/main/mapper/cell/transformation-type-badge/transformation-type-badge.component.ts
+++ b/src/app/main/mapper/cell/transformation-type-badge/transformation-type-badge.component.ts
@@ -34,7 +34,7 @@ export class TransformationTypeBadgeComponent extends OnDestroyMixin {
     } else if (this.target === TransformationTarget.VALUETRANSFORMATION) {
       return this.getSecondaryTransformationType();
     } else if (this.target === TransformationTarget.DATATYPETRANSFORMATION) {
-      return this.getSecondaryTransformationType() && this.isSecondaryType();
+      return this.getSecondaryTypeLabel() && this.isSecondaryType();
     }
   }
 
@@ -128,7 +128,7 @@ export class TransformationTypeBadgeComponent extends OnDestroyMixin {
     } else {
       transformationType = this.getTransformationType();
     }
-    let cssClass = 'type-';
+    let cssClass = 'ti-transform type-';
     if (transformationType === this.GREL) {
       cssClass += this.GREL;
     } else if (transformationType === this.PREFIX) {
@@ -139,17 +139,17 @@ export class TransformationTypeBadgeComponent extends OnDestroyMixin {
 
   resolveDatatypeTransformationTypeClass() {
     const transformationType = this.getType();
-    let cssClass = 'type-';
+    let cssClass = 'ti-type type-';
     if (transformationType === this.DATATYPE_LITERAL) {
-      cssClass += 'datatype';
+      cssClass += 'datatype_literal';
     } else if (transformationType === this.LANGUAGE_LITERAL) {
-      cssClass += 'language-literal';
+      cssClass += 'language_literal';
     }
     return cssClass;
   }
 
   private resolveExpressionValue(transformation) {
     const expression = transformation.getExpression();
-    return expression || COLON;
+    return expression.indexOf(':') >=0 ? expression : expression + COLON;
   }
 }

--- a/src/app/main/mapper/cell/type-badge/type-badge.component.ts
+++ b/src/app/main/mapper/cell/type-badge/type-badge.component.ts
@@ -23,16 +23,35 @@ export class TypeBadgeComponent extends OnDestroyMixin {
 
   public getValueTypeLabel() {
     if (this.type) {
-      const typeUpperCase = this.type.toUpperCase();
+      let typeUpperCase;
+      if (this.type === Type.DatatypeLiteral || this.type === Type.LanguageLiteral) {
+        typeUpperCase = Type.Literal.toUpperCase();
+      } else {
+        typeUpperCase = this.type.toUpperCase();
+      }
+
       const labelKey = `LABELS.${typeUpperCase}`;
-      return this.translateService.instant(labelKey);
+      const labelValue = this.translateService.instant(labelKey);
+      if (this.type === Type.IRI) {
+        return '<' + labelValue + '>';
+      }
+      if (this.type === Type.ValueBnode || this.type === Type.UniqueBnode) {
+        return '_:' + labelValue;
+      }
+      if (this.type === Type.DatatypeLiteral || this.type === Type.LanguageLiteral || this.type === Type.Literal) {
+        return '"' + labelValue + '"';
+      }
     }
   }
 
   public getClass() {
     let cssClass = '';
     if (this.type) {
-      cssClass = `type-${this.type}`;
+      if (this.type === Type.LanguageLiteral || this.type === Type.DatatypeLiteral) {
+        cssClass = `type-${Type.Literal}`;
+      } else {
+        cssClass = `type-${this.type}`;
+      }
     }
     return cssClass;
   }

--- a/src/styles/partials/rdf-mapping.css
+++ b/src/styles/partials/rdf-mapping.css
@@ -64,9 +64,9 @@
 }
 
 .triples-block::after {
-  font-size: 2.5rem;
+  font-size: 1.5rem;
   padding: 0 0.3rem;
-  color: #ccc;
+  color: #5c5c5c;
   align-self: center;
   margin-top: -0.4rem;
 }
@@ -143,7 +143,8 @@
   border-top:1px solid #eee
 }
 .ti-preview {
-  font-size: 1.5em;
+  font-size: 1.0em;
+  font-family: Menlo, Consolas, "Ubuntu Mono", monospace;
   word-break: break-all;
   margin-right: 0.5rem;
 }
@@ -159,24 +160,24 @@
 }
 
 .ti-source-type {
-  background-color: gray;
+  background-color: #F79F88;
   border-radius: 20rem;
   color: #fff;
-  font-size: 0.875rem;
-  width: 1.2rem;
-  height: 1.2rem;
+  font-size: 0.7rem;
+  width: 1.0rem;
+  height: 1.0rem;
   display: inline-block;
   text-align: center;
-  line-height: 1.2rem;
+  line-height: 1.0rem;
   font-weight: 300;
 }
-.ti-source-type.type-col { background-color: red }
-.ti-source-type.type-const { background-color: #c92d39 }
+.ti-source-type.type-col { background-color: #F79F88 }
+.ti-source-type.type-const { display: none }
 
 
 /* Transformations */
 .ti-transform {
-  background-color: #ED4F2F;
+  background-color: #F79F88;
   color: #fff;
   padding: 0.125rem 0.5rem 0.1rem 0.5rem;
   border-radius: 20rem;
@@ -190,21 +191,27 @@
   text-align: right;
   max-width: 50%;
 }
-.ti-transform.type-grel {background-color: rgb(255, 0, 255)}
-.ti-transform.type-prefix {background-color: rgb(70, 189, 198)}
+.ti-transform.type-prefix {
+  color: #0DB19F;
+  background-color: inherit;
+  font-size: 1rem;
+}
 
+.ti-transform.type-grel {
+  font-size: 0.7rem;
+}
 
 /* Types */
 .ti-type {
-  font-weight: 700;
+  font-family: Menlo, Consolas, "Ubuntu Mono", monospace;
   white-space: nowrap;
 }
 .ti-type.type-iri {color: rgb(66, 133, 244)}
-.ti-type.type-unique_bnode {color: rgb(191, 144, 0)}
-.ti-type.type-value_bnode {color: rgb(191, 144, 0)}
-.ti-type.type-literal {color: rgb(52, 168, 83)}
-.ti-type.type-datatype_literal {color: rgb(160, 190, 0)}
-.ti-type.type-language_literal {color: rgb(160, 190, 0)}
+.ti-type.type-unique_bnode {color: rgb(66, 133, 244)}
+.ti-type.type-value_bnode {color: rgb(66, 133, 244)}
+.ti-type.type-literal {color: rgb(66, 133, 244)}
+.ti-type.type-datatype_literal {color: #7AB2E1}
+.ti-type.type-language_literal {color: #7AB2E1}
 
 
 /* empty row */


### PR DESCRIPTION
Show GREL as a source in cell configuration, do not show source when source is GREL, show partial GREL expression

Show type as Literal for datatype and language, show the secondary type properly
Embrace the type labels with some special characters
Show the ':' for the prefixes in the table
Apply new color scheme