### PR TITLE
GDB-5338 Disallow input of new line in fields

### DIFF
--- a/cypress/steps/edit-dialog-steps.ts
+++ b/cypress/steps/edit-dialog-steps.ts
@@ -1,10 +1,10 @@
 import {MapperComponentSelectors} from '../utils/selectors/mapper-component.selectors';
+import MappingSteps from '../steps/mapping-steps';
 
 /**
  * Common edit mapping dialog steps.
  */
 class EditDialogSteps {
-
   static getDialog() {
     return cy.cypressData(MapperComponentSelectors.MAPPER_DIALOG_SELECTOR);
   }
@@ -18,7 +18,7 @@ class EditDialogSteps {
   }
 
   static saveConfiguration() {
-    cy.wait(500)
+    cy.wait(500);
     this.getOkButton().click();
     this.getDialog().should('not.be.visible');
   }
@@ -35,7 +35,7 @@ class EditDialogSteps {
   static clearColumnValue() {
     // in order to close the autocomplete dialog, simulate [esc] key click
     return EditDialogSteps.getColumnField().clear().type('{esc}', {
-      parseSpecialCharSequences: true
+      parseSpecialCharSequences: true,
     });
   }
 
@@ -86,20 +86,23 @@ class EditDialogSteps {
     return this.getLiteralTypeSection().find('[appCypressData=language-constant]').click();
   }
 
+  static selectLanguageColumn() {
+    return this.getLiteralTypeSection().find('[appCypressData=language-column]').click();
+  }
+
   static completeLanguageConstant(value: string) {
     return this.getLiteralTypeSection().find('[appCypressData=language-constant-input]').should('be.visible').type(value).blur();
   }
 
-
-  static selectSourceTypeColumn() {
-    return this.getTypeSection().find('[appCypressData=datatype-column]').click();
+  static selectDataTypeColumn() {
+    return this.getLiteralTypeSection().find('[appCypressData=datatype-column]').click();
   }
 
   static completeSourceTypeColumn(value: string) {
-    return this.getTypeSection().find('[appCypressData=datatype-column-input]').should('be.visible')
-      .type(value + '{esc}', {
-        parseSpecialCharSequences: true
-      }).blur();
+    return this.getLiteralTypeSection().find('[appCypressData=datatype-column-input]').should('be.visible')
+        .type(value + '{esc}', {
+          parseSpecialCharSequences: true,
+        }).blur();
   }
 
   // source section
@@ -113,7 +116,6 @@ class EditDialogSteps {
 
   static getConstantField() {
     return this.getSourceSection().find('[appCypressData=constant-input]');
-
   }
   static completeConstant(value: string) {
     return this.getConstantField().should('be.visible').type(value).blur();
@@ -121,7 +123,7 @@ class EditDialogSteps {
 
   static clearConstantValue() {
     return EditDialogSteps.getConstantField().clear().type('{esc}', {
-      parseSpecialCharSequences: true
+      parseSpecialCharSequences: true,
     });
   }
 
@@ -204,7 +206,7 @@ class EditDialogSteps {
 
   static clearDataTypeExpression() {
     return this.getDataTypeExpressionField().should('be.visible').clear().type('{esc}', {
-      parseSpecialCharSequences: true
+      parseSpecialCharSequences: true,
     });
   }
 
@@ -247,20 +249,28 @@ class EditDialogSteps {
   static completePrefix(prefix: string) {
     // emulate [esc] button hit in order to close the autocomplete
     return this.getTransformationExpressionField().should('be.visible').type(`${prefix}{esc}`, {
-      parseSpecialCharSequences: true
+      parseSpecialCharSequences: true,
     });
   }
 
   static clearPrefix() {
     return this.getTransformationExpressionField().should('be.visible').clear().type('{esc}', {
-      parseSpecialCharSequences: true
+      parseSpecialCharSequences: true,
     });
   }
 
   static getPrefixSuggestions() {
-    return cy.get('.mat-autocomplete-panel').find(`[appCypressData="prefix-suggestion"]`)
+    return cy.get('.mat-autocomplete-panel').find(`[appCypressData="prefix-suggestion"]`);
   }
 
+  static getColumnSuggestions() {
+    return cy.get('.mat-autocomplete-panel').find(`[appCypressData="column-suggestion"]`);
+  }
+
+  static assertNewLineNotAddedToField(fieldAccessorCb: any) {
+    MappingSteps.type('{enter}', () => fieldAccessorCb);
+    fieldAccessorCb.should('have.value', '');
+  }
 }
 
 export default EditDialogSteps;

--- a/cypress/steps/mapping-steps.ts
+++ b/cypress/steps/mapping-steps.ts
@@ -252,7 +252,7 @@ class MappingSteps {
   }
 
   // This is for the empty cell edit!!!
-  static editTripleObject(index: number) {
+  static editEmptyTripleObject(index: number) {
     return MappingSteps.getTripleObject(index).find('[appCypressData="button-edit-empty-cell"]').click();
   }
 

--- a/cypress/test/amsterdam-mapping.spec.ts
+++ b/cypress/test/amsterdam-mapping.spec.ts
@@ -44,7 +44,7 @@ describe('Create Amsterdam restaurants mapping', () => {
     // I create predicate with constant
     MappingSteps.completePredicate(2, 'name');
     // I create language literal object
-    MappingSteps.editTripleObject(2);
+    MappingSteps.editEmptyTripleObject(2);
     EditDialogSteps.selectTypeLanguageLiteral();
     EditDialogSteps.selectLanguageConstant();
     EditDialogSteps.completeLanguageConstant('nl');
@@ -56,7 +56,7 @@ describe('Create Amsterdam restaurants mapping', () => {
     // I create predicate with constant
     MappingSteps.completePredicate(4, 'description');
     // I create language literal object
-    MappingSteps.editTripleObject(4);
+    MappingSteps.editEmptyTripleObject(4);
     EditDialogSteps.selectTypeLanguageLiteral();
     EditDialogSteps.selectLanguageConstant();
     EditDialogSteps.completeLanguageConstant('nl');
@@ -68,7 +68,7 @@ describe('Create Amsterdam restaurants mapping', () => {
     // I create predicate with constant with prefix
     MappingSteps.completePredicate(6, 'geo:hasGeometry');
     // I create object with column source and GREL transformation
-    MappingSteps.editTripleObject(6);
+    MappingSteps.editEmptyTripleObject(6);
     EditDialogSteps.selectIri();
     EditDialogSteps.selectGREL();
     EditDialogSteps.completeGREL('"https://data.amsterdam.nl/resource/geometry/" + value');
@@ -83,7 +83,7 @@ describe('Create Amsterdam restaurants mapping', () => {
     MappingSteps.addTriplePredicateSibling(7);
     MappingSteps.completePredicate(8, 'geo:asWKT');
     // I create datatype object with constant with prefix and row index source with GREL transformation
-    MappingSteps.editTripleObject(8);
+    MappingSteps.editEmptyTripleObject(8);
     EditDialogSteps.selectTypeDataTypeLiteral();
     EditDialogSteps.selectDataTypeConstant();
     EditDialogSteps.completeDataTypeConstant('wktLiteral');
@@ -97,7 +97,7 @@ describe('Create Amsterdam restaurants mapping', () => {
 
     MappingSteps.completePredicate(9, 'valuenode');
     // I add a value bnode with source column
-    MappingSteps.editTripleObject(9);
+    MappingSteps.editEmptyTripleObject(9);
     EditDialogSteps.selectValueBnode();
     EditDialogSteps.selectColumn();
     EditDialogSteps.completeColumn('Trcid');
@@ -107,7 +107,7 @@ describe('Create Amsterdam restaurants mapping', () => {
     MappingSteps.addNestedTriple(9);
     MappingSteps.completePredicate(10, 'longdescription');
     // I add a value bnode with source column
-    MappingSteps.editTripleObject(10);
+    MappingSteps.editEmptyTripleObject(10);
     EditDialogSteps.selectLiteral();
     EditDialogSteps.selectColumn();
     EditDialogSteps.completeColumn('Longdescription');
@@ -117,7 +117,7 @@ describe('Create Amsterdam restaurants mapping', () => {
     MappingSteps.addNestedTriple(9);
     MappingSteps.completePredicate(11, 'uniquenode');
     // I add a value bnode with source column
-    MappingSteps.editTripleObject(11);
+    MappingSteps.editEmptyTripleObject(11);
     EditDialogSteps.selectUniqueBnode();
     EditDialogSteps.selectColumn();
     EditDialogSteps.completeColumn('Media');
@@ -126,7 +126,7 @@ describe('Create Amsterdam restaurants mapping', () => {
     MappingSteps.addNestedTriple(11);
     MappingSteps.completePredicate(12, 'city');
     // I add a value bnode with source column
-    MappingSteps.editTripleObject(12);
+    MappingSteps.editEmptyTripleObject(12);
     EditDialogSteps.selectLiteral();
     EditDialogSteps.selectColumn();
     EditDialogSteps.completeColumn('City');

--- a/cypress/test/autocomplete.spec.ts
+++ b/cypress/test/autocomplete.spec.ts
@@ -1,6 +1,7 @@
 import MappingSteps from '../steps/mapping-steps';
 import EditDialogSteps from '../steps/edit-dialog-steps';
 import PrepareSteps from '../steps/prepare-steps';
+import {MapperComponentSelectors} from '../utils/selectors/mapper-component.selectors';
 
 describe('Autocomplete mapping', () => {
 
@@ -78,6 +79,46 @@ describe('Autocomplete mapping', () => {
       EditDialogSteps.selectConstant();
       EditDialogSteps.getTransformationExpressionField().click();
       EditDialogSteps.getPrefixSuggestions().first().contains('rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>');
+    });
+
+    it('Should not allow entering a new line in text areas', () => {
+      MappingSteps.completeTriple(0, 'subject', 'predicate', undefined);
+
+      MappingSteps.editEmptyTripleObject(0);
+      EditDialogSteps.selectColumn();
+      EditDialogSteps.getColumnField().click();
+      // When I try to press {enter} in text area, new line should not be added
+      EditDialogSteps.assertNewLineNotAddedToField(EditDialogSteps.getColumnField());
+      // When 'col' is typed in textarea
+      MappingSteps.type('col', () => EditDialogSteps.getColumnField());
+      // There should be suggestion dropdown
+      // And should contain 'color' as first option
+      EditDialogSteps.getColumnSuggestions().first().contains('color');
+      // When no option is selected and {enter} is pressed
+      MappingSteps.type('{enter}', () => EditDialogSteps.getColumnField());
+      // Text in textarea should not be autocompleted
+      EditDialogSteps.getColumnField().should('have.value', 'col');
+
+      EditDialogSteps.selectConstant();
+      EditDialogSteps.assertNewLineNotAddedToField(EditDialogSteps.getConstantField());
+      EditDialogSteps.selectGREL();
+      EditDialogSteps.assertNewLineNotAddedToField(EditDialogSteps.getTransformationExpressionField());
+
+      EditDialogSteps.selectTypeDataTypeLiteral();
+      EditDialogSteps.selectDataTypeColumn();
+      EditDialogSteps.assertNewLineNotAddedToField(cy.cypressData(MapperComponentSelectors.DATATYPE_COLUMN_INPUT));
+      EditDialogSteps.selectDataTypeConstant();
+      EditDialogSteps.assertNewLineNotAddedToField(cy.cypressData(MapperComponentSelectors.DATATYPE_CONSTANT_INPUT));
+      EditDialogSteps.selectDataTypeGREL();
+      EditDialogSteps.assertNewLineNotAddedToField(cy.cypressData(MapperComponentSelectors.DATATYPE_TRANSFORMATION_EXPRESSION));
+
+      EditDialogSteps.selectTypeLanguageLiteral();
+      EditDialogSteps.selectLanguageColumn();
+      EditDialogSteps.assertNewLineNotAddedToField(cy.cypressData(MapperComponentSelectors.LANGUAGE_COLUMN_INPUT));
+      EditDialogSteps.selectLanguageConstant();
+      EditDialogSteps.assertNewLineNotAddedToField(cy.cypressData(MapperComponentSelectors.LANGUAGE_CONSTANT_INPUT));
+      EditDialogSteps.selectLanguageGREL();
+      EditDialogSteps.assertNewLineNotAddedToField(cy.cypressData(MapperComponentSelectors.LANGUAGE_TRANSFORMATION_EXPRESSION));
     });
   });
 });

--- a/cypress/test/delete.spec.ts
+++ b/cypress/test/delete.spec.ts
@@ -54,7 +54,7 @@ describe('Delete', () => {
       MappingSteps.getTriples().should('have.length', 1);
       // And I have created a triple
       MappingSteps.completeTriple(0, 'sub', 'pre', undefined);
-      MappingSteps.editTripleObject(0);
+      MappingSteps.editEmptyTripleObject(0);
       EditDialogSteps.getDialog().should('be.visible');
       EditDialogSteps.selectIri();
       EditDialogSteps.selectConstant();

--- a/cypress/test/edit-mapping.spec.ts
+++ b/cypress/test/edit-mapping.spec.ts
@@ -249,7 +249,7 @@ describe('Edit mapping', () => {
       // When I load application
       PrepareSteps.visitPageAndWaitToLoad();
       MappingSteps.completeTriple(0, 'subject', 'predicate', undefined);
-      MappingSteps.editTripleObject(0);
+      MappingSteps.editEmptyTripleObject(0);
       EditDialogSteps.selectIri();
       EditDialogSteps.selectGREL();
       EditDialogSteps.completeGREL('cells["director_name"].value');

--- a/cypress/test/namespaces.spec.ts
+++ b/cypress/test/namespaces.spec.ts
@@ -187,7 +187,7 @@ context('Namespaces', () => {
       // WHEN I complete the subject and predicate
       MappingSteps.completeTriple(0, 'sub', 'pred', undefined);
       // And edit the object
-      MappingSteps.editTripleObject(0);
+      MappingSteps.editEmptyTripleObject(0);
       EditDialogSteps.selectIri();
       EditDialogSteps.selectConstant();
       EditDialogSteps.completeConstant('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
@@ -204,7 +204,7 @@ context('Namespaces', () => {
       // WHEN I complete the subject ans predicate
       MappingSteps.completeTriple(0, 'sub', 'pred', undefined);
       // And edit the object
-      MappingSteps.editTripleObject(0);
+      MappingSteps.editEmptyTripleObject(0);
       EditDialogSteps.selectLiteral();
       EditDialogSteps.selectConstant();
       EditDialogSteps.completeConstant('http://www.w3.org/1999/02/22-rdf-syntax-ns#');

--- a/src/app/main/mapper/cell/empty-block/empty-block.component.ts
+++ b/src/app/main/mapper/cell/empty-block/empty-block.component.ts
@@ -223,6 +223,9 @@ export class EmptyBlockComponent extends OnDestroyMixin implements OnInit, After
   }
 
   public saveInputValue(emitTab: boolean) {
+    if (!this.autoInput.value) {
+      return;
+    }
     let value = this.autoInput.value.trim();
     if (this.manualInput && !this.autoInput.value.startsWith(this.manualInput)) {
       value = this.manualInput + this.autoInput.value;

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.html
@@ -56,36 +56,43 @@
             <div fxFlex="20">
               <span>{{'LABELS.CONSTANT' | translate}}</span>
             </div>
-            <div fxFlex="none" *ngIf="isIri()">
-              <mat-button-toggle-group formControlName="language" multiple (change)="toggleValueChange($event, 'language')">
-                <mat-button-toggle *ngFor="let lang of valueTransformationLangs" [value]="lang"
-                                   [attr.appCypressData]="'transformation-'+ lang">
-                  {{getType(lang)}}
-                </mat-button-toggle>
-              </mat-button-toggle-group>
-            </div>
-            <div fxFlex="none" *ngIf="isIri()" class="transformation-section" appCypressData="transformation-section">
-              <mat-form-field class="ml-16">
-                <mat-label>{{'TYPE.PREFIX' | translate}}</mat-label>
-                <input matInput formControlName="expression" name="expression"
-                          [matAutocomplete]="prefixAuto"
-                          appCypressData="transformation-expression" [readonly]="isRawIri">
-                <mat-autocomplete #prefixAuto="matAutocomplete">
-                  <div>
-                    <mat-option *ngFor="let namespace of filteredNamespaces | async" [value]="namespace.prefix || ':'" appCypressData="prefix-suggestion">
-                      {{namespace.prefix}}: <{{namespace.pValue}}>
-                    </mat-option>
-                  </div>
-                </mat-autocomplete>
-              </mat-form-field>
-            </div>
-            <div *ngIf="isIri()" class="mr-8 ml-8" fxFlex="none">{{"LABELS.COLON_DIVIDER" | translate}}</div>
+            <ng-container *ngIf="isIri()">
+              <div fxFlex="none">
+                <mat-button-toggle-group formControlName="language" multiple
+                                         (change)="toggleValueChange($event, 'language')">
+                  <mat-button-toggle *ngFor="let lang of valueTransformationLangs" [value]="lang"
+                                     [attr.appCypressData]="'transformation-'+ lang">
+                    {{getType(lang)}}
+                  </mat-button-toggle>
+                </mat-button-toggle-group>
+              </div>
+              <div fxFlex="none" class="transformation-section" appCypressData="transformation-section">
+                <mat-form-field class="ml-16">
+                  <mat-label>{{'TYPE.PREFIX' | translate}}</mat-label>
+                  <input matInput formControlName="expression" name="expression"
+                         [matAutocomplete]="prefixAuto"
+                         appCypressData="transformation-expression" [readonly]="isRawIri">
+                  <mat-autocomplete #prefixAuto="matAutocomplete">
+                    <div>
+                      <mat-option *ngFor="let namespace of filteredNamespaces | async" [value]="namespace.prefix || ':'"
+                                  appCypressData="prefix-suggestion">
+                        {{namespace.prefix}}: <{{namespace.pValue}}>
+                      </mat-option>
+                    </div>
+                  </mat-autocomplete>
+                </mat-form-field>
+              </div>
+              <div class="mr-8 ml-8" fxFlex="none">{{"LABELS.COLON_DIVIDER" | translate}}</div>
+            </ng-container>
             <mat-form-field fxFlex="80">
               <textarea matInput formControlName="constant" name="constant" cdkTextareaAutosize
-                              cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
-                              [placeholder]="('LABELS.CONSTANT' | translate)"
-                              [matAutocomplete]="autoType"
-                              appCypressData="constant-input"></textarea>
+                        cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
+                        [placeholder]="('LABELS.CONSTANT' | translate)"
+                        [matAutocomplete]="autoType"
+                        appCypressData="constant-input"
+                        #trigger="matAutocompleteTrigger"
+                        (keydown.enter)="onKeydownEnter($event)"
+                        (keyup.enter)="makeSelection($event, trigger)"></textarea>
               <mat-error *ngIf="mapperForm.get('constant').hasError('required')" appCypressData="constant-error">
                 {{ 'ERROR.REQUIRED' | translate }}
               </mat-error>
@@ -102,42 +109,47 @@
             <div fxFlex="20">
               <span>{{'LABELS.COLUMN_NAME' | translate}}</span>
             </div>
-            <div fxFlex="none" *ngIf="isIri()">
-              <mat-button-toggle-group formControlName="language" multiple (change)="toggleValueChange($event, 'language')">
-                <mat-button-toggle *ngFor="let lang of valueTransformationLangs" [value]="lang"
-                                   [attr.appCypressData]="'transformation-'+ lang">
-                  {{getType(lang)}}
-                </mat-button-toggle>
-              </mat-button-toggle-group>
-            </div>
-            <div fxFlex="none" *ngIf="isIri()" class="transformation-section" appCypressData="transformation-section">
-              <mat-form-field class="ml-16">
-                <mat-label>{{'TYPE.PREFIX' | translate}}</mat-label>
-                <input matInput formControlName="expression" name="expression"
-                          [matAutocomplete]="prefixAuto"
-                          appCypressData="transformation-expression" [readonly]="isRawIri">
-                <mat-autocomplete #prefixAuto="matAutocomplete">
-                  <div>
-                    <mat-option *ngFor="let namespace of filteredNamespaces | async" [value]="namespace.prefix || ':'" appCypressData="prefix-suggestion">
-                      {{namespace.prefix}}: <{{namespace.pValue}}>
-                    </mat-option>
-                  </div>
-                </mat-autocomplete>
-              </mat-form-field>
-            </div>
-            <div *ngIf="isIri()" class="mr-8 ml-8" fxFlex="none">{{"LABELS.COLON_DIVIDER" | translate}}</div>
+            <ng-container *ngIf="isIri()">
+              <div fxFlex="none">
+                <mat-button-toggle-group formControlName="language" multiple (change)="toggleValueChange($event, 'language')">
+                  <mat-button-toggle *ngFor="let lang of valueTransformationLangs" [value]="lang"
+                                     [attr.appCypressData]="'transformation-'+ lang">
+                    {{getType(lang)}}
+                  </mat-button-toggle>
+                </mat-button-toggle-group>
+              </div>
+              <div fxFlex="none" class="transformation-section" appCypressData="transformation-section">
+                <mat-form-field class="ml-16">
+                  <mat-label>{{'TYPE.PREFIX' | translate}}</mat-label>
+                  <input matInput formControlName="expression" name="expression"
+                         [matAutocomplete]="prefixAuto"
+                         appCypressData="transformation-expression" [readonly]="isRawIri">
+                  <mat-autocomplete #prefixAuto="matAutocomplete">
+                    <div>
+                      <mat-option *ngFor="let namespace of filteredNamespaces | async" [value]="namespace.prefix || ':'" appCypressData="prefix-suggestion">
+                        {{namespace.prefix}}: <{{namespace.pValue}}>
+                      </mat-option>
+                    </div>
+                  </mat-autocomplete>
+                </mat-form-field>
+              </div>
+              <div class="mr-8 ml-8" fxFlex="none">{{"LABELS.COLON_DIVIDER" | translate}}</div>
+            </ng-container>
             <mat-form-field fxFlex="80">
-                    <textarea matInput formControlName="columnName" name="columnName"
-                              cdkTextareaAutosize
-                              cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
-                              [placeholder]="('LABELS.COLUMN_NAME' | translate)"
-                              [matAutocomplete]="autoc"
-                              appCypressData="column-input"></textarea>
+              <textarea matInput formControlName="columnName" name="columnName"
+                        cdkTextareaAutosize
+                        cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
+                        [placeholder]="('LABELS.COLUMN_NAME' | translate)"
+                        [matAutocomplete]="autoc"
+                        appCypressData="column-input"
+                        #trigger="matAutocompleteTrigger"
+                        (keydown.enter)="onKeydownEnter($event)"
+                        (keyup.enter)="makeSelection($event, trigger)"></textarea>
               <mat-error *ngIf="mapperForm.get('columnName').hasError('required')" appCypressData="column-error">
-                {{ 'ERROR.REQUIRED' | translate }}
+              {{ 'ERROR.REQUIRED' | translate }}
               </mat-error>
               <mat-autocomplete #autoc="matAutocomplete">
-                <mat-option *ngFor="let option of filteredColumnNames | async" [value]="option.title">
+                <mat-option *ngFor="let option of filteredColumnNames | async" [value]="option.title" appCypressData="column-suggestion">
                   {{option.title}}
                 </mat-option>
               </mat-autocomplete>
@@ -149,12 +161,14 @@
               <span>{{'LABELS.GREL' | translate}}</span>
             </div>
             <mat-form-field fxFlex="80">
-                     <textarea matInput formControlName="grelExpression" name="grelExpression"
-                               cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
-                               [placeholder]="('LABELS.GREL_PLACEHOLDER' | translate)"
-                               appCypressData="transformation-expression"
-                               [satPopoverAnchor]='expressionGrelPreview'
-                               (focus)="expressionGrelPreview.open()" (blur)="expressionGrelPreview.close()"></textarea>
+               <textarea matInput formControlName="grelExpression" name="grelExpression"
+                         cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
+                         [placeholder]="('LABELS.GREL_PLACEHOLDER' | translate)"
+                         appCypressData="transformation-expression"
+                         [satPopoverAnchor]='expressionGrelPreview'
+                         (focus)="expressionGrelPreview.open()"
+                         (blur)="expressionGrelPreview.close()"
+                         (keydown.enter)="onKeydownEnter($event)"></textarea>
               <mat-icon matSuffix>
                 <a class="icon-info"  target="_blank" href={{environment.openRefineVariables}}
                    matTooltip="{{'TOOLTIPS.GREL_VALUE_HELP' | translate}}"></a>
@@ -247,7 +261,10 @@
                               cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
                               [placeholder]="('LABELS.CONSTANT' | translate)"
                               [matAutocomplete]="autoDataTypeC"
-                              appCypressData="datatype-constant-input"></textarea>
+                              appCypressData="datatype-constant-input"
+                              #trigger="matAutocompleteTrigger"
+                              (keydown.enter)="onKeydownEnter($event)"
+                              (keyup.enter)="makeSelection($event, trigger)"></textarea>
                   <mat-error *ngIf="mapperForm.get('dataTypeConstant').hasError('required')"
                              appCypressData="datatype-constant-error">
                     {{ 'ERROR.REQUIRED' | translate }}
@@ -295,13 +312,16 @@
                               cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
                               [placeholder]="('LABELS.COLUMN_NAME' | translate)"
                               [matAutocomplete]="autoc"
-                              appCypressData="datatype-column-input"></textarea>
+                              appCypressData="datatype-column-input"
+                              #trigger="matAutocompleteTrigger"
+                              (keydown.enter)="onKeydownEnter($event)"
+                              (keyup.enter)="makeSelection($event, trigger)"></textarea>
                   <mat-error *ngIf="mapperForm.get('dataTypeColumnName').hasError('required')"
                              appCypressData="datatype-column-error">
                     {{ 'ERROR.REQUIRED' | translate }}
                   </mat-error>
                   <mat-autocomplete #autoc="matAutocomplete">
-                    <mat-option *ngFor="let option of filteredColumnNames | async" [value]="option.title">
+                    <mat-option *ngFor="let option of filteredColumnNames | async" [value]="option.title" appCypressData="column-suggestion">
                       {{option.title}}
                     </mat-option>
                   </mat-autocomplete>
@@ -318,7 +338,8 @@
                                [placeholder]="('LABELS.GREL_PLACEHOLDER' | translate)"
                                appCypressData="datatype-transformation-expression"
                                [satPopoverAnchor]='datatypeGrelPreview'
-                               (focus)="datatypeGrelPreview.open()" (blur)="datatypeGrelPreview.close()"></textarea>
+                               (focus)="datatypeGrelPreview.open()" (blur)="datatypeGrelPreview.close()"
+                               (keydown.enter)="onKeydownEnter($event)"></textarea>
                   <mat-icon matSuffix>
                     <a class="icon-info"  target="_blank" href={{environment.openRefineVariables}}
                        matTooltip="{{'TOOLTIPS.GREL_VALUE_HELP' | translate}}"></a>
@@ -366,7 +387,8 @@
                     <textarea matInput formControlName="languageConstant" name="languageConstant" cdkTextareaAutosize
                               cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
                               [placeholder]="('LABELS.CONSTANT' | translate)"
-                              appCypressData="language-constant-input"></textarea>
+                              appCypressData="language-constant-input"
+                              (keydown.enter)="onKeydownEnter($event)"></textarea>
                   <mat-error *ngIf="mapperForm.get('languageConstant').hasError('required')"
                              appCypressData="language-constant-error">
                     {{ 'ERROR.REQUIRED' | translate }}
@@ -384,13 +406,16 @@
                               cdkAutosizeMinRows="1" cdkAutosizeMaxRows="5"
                               [placeholder]="('LABELS.COLUMN_NAME' | translate)"
                               [matAutocomplete]="autoc"
-                              appCypressData="language-column-input"></textarea>
+                              appCypressData="language-column-input"
+                              #trigger="matAutocompleteTrigger"
+                              (keydown.enter)="onKeydownEnter($event)"
+                              (keyup.enter)="makeSelection($event, trigger)"></textarea>
                   <mat-error *ngIf="mapperForm.get('languageColumnName').hasError('required')"
                              appCypressData="language-column-error">
                     {{ 'ERROR.REQUIRED' | translate }}
                   </mat-error>
                   <mat-autocomplete #autoc="matAutocomplete">
-                    <mat-option *ngFor="let option of filteredColumnNames | async" [value]="option.title">
+                    <mat-option *ngFor="let option of filteredColumnNames | async" [value]="option.title" appCypressData="column-suggestion">
                       {{option.title}}
                     </mat-option>
                   </mat-autocomplete>
@@ -407,7 +432,8 @@
                               [placeholder]="('LABELS.GREL_PLACEHOLDER' | translate)"
                               appCypressData="language-transformation-expression"
                               [satPopoverAnchor]='languageGrelPreview'
-                              (focus)="languageGrelPreview.open()" (blur)="languageGrelPreview.close()"></textarea>
+                              (focus)="languageGrelPreview.open()" (blur)="languageGrelPreview.close()"
+                              (keydown.enter)="onKeydownEnter($event)"></textarea>
                   <mat-icon matSuffix>
                     <a class="icon-info"  target="_blank" href={{environment.openRefineVariables}}
                        matTooltip="{{'TOOLTIPS.GREL_VALUE_HELP' | translate}}"></a>

--- a/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
+++ b/src/app/main/mapper/mapper-dialog/mapper-dialog.component.ts
@@ -30,6 +30,7 @@ import {MappingDefinitionSource} from 'src/app/models/mapping-definition-source'
 import {MatButtonToggleChange} from '@angular/material/button-toggle';
 import {MappingDefinitionLiteralType} from 'src/app/models/mapping-definition-literal-type';
 import {MappingDefinitionLiteralSource} from 'src/app/models/mapping-definition-literal-source';
+import {MatAutocompleteTrigger} from '@angular/material/autocomplete';
 
 export interface SubjectMapperData {
   mappingData: Triple;
@@ -864,5 +865,14 @@ export class MapperDialogComponent extends OnDestroyMixin implements OnInit {
 
   isIri(): boolean {
     return this.isOfType(Type.IRI) || this.checkIsTypePropertyObject() || this.isSubject() || this.isPredicate();
+  }
+
+  public makeSelection(event: KeyboardEvent, trigger: MatAutocompleteTrigger) {
+    event.preventDefault();
+    trigger.closePanel();
+  }
+
+  public onKeydownEnter(event: KeyboardEvent) {
+    event.preventDefault();
   }
 }


### PR DESCRIPTION
- All enter key events in `textarea` tags are handled and entering a new line is prevented.
- If there is an autocomplete dropdown with no current selection, it is closed and text in field remains as is. If there is a selection the text field is autocompleted.
- Fixed bug for an error for trim() operation on null when input in empty block (sub/pred/obj) is null and trying to save value.