### PR TITLE
GDB-5406 Propagated event to certain domain

### DIFF
--- a/src/app/main/mapper/header/header.component.ts
+++ b/src/app/main/mapper/header/header.component.ts
@@ -51,11 +51,10 @@ export class HeaderComponent extends OnDestroyMixin implements OnInit {
         .pipe(untilComponentDestroyed(this))
         .subscribe((event) => {
           this.isMappingDirty = event.getMessage();
-          // TODO Replace the wildcard with the domain on which WB is running. See https://ontotext.atlassian.net/browse/GDB-5406
           if (this.isMappingDirty) {
-            window.parent.postMessage(DIRTY_MAPPING, '*'); // nosonar
+            window.parent.postMessage(DIRTY_MAPPING, environment.graphDbUrl);
           } else {
-            window.parent.postMessage(PRISTINE_MAPPING, '*'); // nosonar
+            window.parent.postMessage(PRISTINE_MAPPING, environment.graphDbUrl);
           }
         });
 

--- a/src/app/main/mapper/mapper.component.ts
+++ b/src/app/main/mapper/mapper.component.ts
@@ -157,6 +157,7 @@ export class MapperComponent extends OnDestroyMixin implements OnInit {
         .pipe(untilComponentDestroyed(this))
         .subscribe((data) => {
           this.messageService.publish(ChannelName.SparqlGenerated);
+          // Have in mind that the redirect does not work in dev mode
           window.parent.open(environment.graphDbUrl + '/sparql?query=' + encodeURIComponent(data));
         });
   }

--- a/src/environments/environment.cypress.ts
+++ b/src/environments/environment.cypress.ts
@@ -1,15 +1,18 @@
 // The cypress tests are running on localhost and port 4200, but the packaging
 // in dist folder is a bit different than the way how mapper is packaged in
-// GDB dist - orefin/extension/mapping-editor
+// GDB dist - orefin/extension/mapping-editor.
+
+// Setting graphDbUrl to 'http://localhost:4200' to match the recipient window's origin.
+// All other requests are mocked
 
 export const environment = {
   production: false,
-  graphDbUrl: '',
-  restApiUrl: 'http://localhost:4200/rest/rdf-mapper',
-  mappingApiUrl: 'http://localhost:4200/orefine/command',
-  repositoryApiUrl: 'http://localhost:4200/repositories',
-  repositoryGDBApiUrl: 'http://localhost:4200/rest/repositories',
-  autocompleteApiUrl: 'http://localhost:4200/rest/autocomplete',
+  graphDbUrl: 'http://localhost:4200',
+  restApiUrl: '/rest/rdf-mapper',
+  mappingApiUrl: '/orefine/command',
+  repositoryApiUrl: '/repositories',
+  repositoryGDBApiUrl: '/rest/repositories',
+  autocompleteApiUrl: '/rest/autocomplete',
   httpLoaderPrefix: './assets/i18n/',
   httpLoaderSuffix: '.json',
   openRefineVariables: 'https://github.com/OpenRefine/OpenRefine/wiki/Variables',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,9 +2,13 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+// In developer mode mapper is running on localhost and port 4200.
+// Setting graphDbUrl to 'http://localhost:4200' to match the recipient window's origin.
+// All other requests are sent to underlying GDB on port 7200.
+
 export const environment = {
   production: false,
-  graphDbUrl: 'http://localhost:7200',
+  graphDbUrl: 'http://localhost:4200',
   restApiUrl: 'http://localhost:7200/rest/rdf-mapper',
   mappingApiUrl: 'http://localhost:7200/orefine/command',
   repositoryApiUrl: 'http://localhost:7200/repositories',


### PR DESCRIPTION
Made postMessage to propagate events to previously detected environment.graphdbUrl in production mode. In the other two profiles dev and cypress-tests latter is mocked to 'http:localhost:4200' on which mapper is running.