### PR TITLE
OR-100 Updates the handler for the SPARQL button

### DIFF
--- a/src/app/main/mapper/mapper.component.ts
+++ b/src/app/main/mapper/mapper.component.ts
@@ -25,7 +25,6 @@ import {NamespaceService} from '../../services/namespace.service';
 import {Namespaces, Namespace} from '../../models/namespaces';
 import {NamespaceValidator} from '../../validators/namespace.validator';
 import * as XRegExp from 'xregexp';
-import {environment} from 'src/environments/environment';
 
 
 @Component({
@@ -155,9 +154,9 @@ export class MapperComponent extends OnDestroyMixin implements OnInit {
   onSPARQL() {
     this.mapperService.getSPARQL(this.mapping)
         .pipe(untilComponentDestroyed(this))
-        .subscribe((data) => {
+        .subscribe((fulUrl) => {
           this.messageService.publish(ChannelName.SparqlGenerated);
-          window.parent.open(environment.graphDbUrl + '/sparql?query=' + encodeURIComponent(data));
+          window.parent.open(fulUrl);
         });
   }
 

--- a/src/app/services/rest/mapper.service.ts
+++ b/src/app/services/rest/mapper.service.ts
@@ -65,11 +65,9 @@ export class MapperService extends RestService {
   }
 
   getSPARQL(mappingDefinition: MappingDefinitionImpl): Observable<string> {
-    const httpOptions = this.httpOptions;
-    httpOptions['reponseType'] = 'text';
     return this.getAPIURL('/sparql/').pipe(switchMap((fullUrl) => {
-      return this.httpClient.post<string>(fullUrl, mappingDefinition, httpOptions).pipe(
-          catchError((error) => this.errorReporterService.handleError('Loading sparql failed.', error)));
+      return this.httpClient.post(fullUrl, mappingDefinition, {headers: this.httpOptions.headers, responseType: 'text'})
+          .pipe(catchError((error) => this.errorReporterService.handleError('Loading sparql failed.', error)));
     }));
   }
 }


### PR DESCRIPTION
- Updated the handler for the SPARQL button to correspond to the changes
in the backend. This is the small part of the changes that will be done
to the Mapping UI due to the splitting of OntoRefine and GraphDB.

When the GraphDB is secured, the users will be redirected to the
Workbench login form, if there isn't active session. Later we may change
this behavior with something more user friendly.