### PR TITLE
OR-160 Updates the SPARQL endpoint path

### DIFF
--- a/cypress/steps/prepare-steps.ts
+++ b/cypress/steps/prepare-steps.ts
@@ -3,14 +3,12 @@ import {MapperComponentSelectors} from "../utils/selectors/mapper-component.sele
 
 class PrepareSteps {
   static prepareMoviesNamespacesAndColumns() {
-    cy.setLocalStorage('com.ontotext.graphdb.repository', 'Movies');
     cy.intercept('GET', '/graphdb-proxy/repositories/repository_placeholder/namespaces', {fixture: 'namespaces.json'});
     cy.intercept('GET', '/rest/rdf-mapper/columns/ontorefine:123', {fixture: 'columns.json'}).as('loadColumns');
     PrepareSteps.setCommonRequests();
   }
 
   static prepareRestaurantsNamespacesAndColumns() {
-    cy.setLocalStorage('com.ontotext.graphdb.repository', 'Restaurants');
     cy.intercept('GET', '/graphdb-proxy/repositories/repository_placeholder/namespaces', {fixture: 'namespaces.json'});
     cy.intercept('GET', '/rest/rdf-mapper/columns/ontorefine:123', {fixture: 'amsterdam/columns.json'}).as('loadColumns');
     PrepareSteps.setCommonRequests();

--- a/cypress/test/create-mapping.cy.ts
+++ b/cypress/test/create-mapping.cy.ts
@@ -26,7 +26,7 @@ describe('Create mapping', () => {
       response: ''
     }).as('loadRdf');
 
-    cy.intercept('POST', '/rest/rdf-mapper/sparql/ontorefine:123', {
+    cy.intercept('POST', '/rest/rdf-mapper/sparql-url-with-query/ontorefine:123', {
       statusCode: 200,
       delay: 1000,
       fixture: 'create-mapping/load-sparql-response',
@@ -79,7 +79,7 @@ describe('Create mapping', () => {
     HeaderSteps.getGenerateSparqlIndicator().should('be.visible');
     // Then I expect sparql to be loaded. The actual download can't be checked
     cy.wait('@loadSparql').then((interception) => {
-      expect(interception.request.url).to.include('/rest/rdf-mapper/sparql/ontorefine:123');
+      expect(interception.request.url).to.include('/rest/rdf-mapper/sparql-url-with-query/ontorefine:123');
       expect(interception.request.method).to.equal('POST');
     });
     cy.get('@loadSparql').should((xhr: any) => {

--- a/cypress/test/edit-mapping.cy.ts
+++ b/cypress/test/edit-mapping.cy.ts
@@ -200,7 +200,7 @@ describe('Edit mapping', () => {
 
     it('Should show error notification when SPARQL generation fails', () => {
       cy.intercept('GET', '/orefine/command/core/get-models/?project=123', {fixture: 'mapping-model.json'}).as('loadProject');
-      cy.intercept('POST', '/rest/rdf-mapper/sparql/ontorefine:123', {
+      cy.intercept('POST', '/rest/rdf-mapper/sparql-url-with-query/ontorefine:123', {
         statusCode: 404,
         fixture: 'edit-mapping/generate-sparql-error',
         headers: {

--- a/src/app/services/rest/mapper.service.ts
+++ b/src/app/services/rest/mapper.service.ts
@@ -64,7 +64,7 @@ export class MapperService extends RestService {
   }
 
   getSPARQL(mappingDefinition: MappingDefinitionImpl): Observable<string> {
-    return this.getAPIURL('/sparql/').pipe(switchMap((fullUrl) => {
+    return this.getAPIURL('/sparql-url-with-query/').pipe(switchMap((fullUrl) => {
       return this.httpClient.post(fullUrl, mappingDefinition, {headers: this.httpOptions.headers, responseType: 'text'})
           .pipe(catchError((error) => this.handleError('sparql', error)));
     }));


### PR DESCRIPTION
- To keep the Mapper API (backend) unchanged, we've introduced different
endpoint, which returns the SPARQL URL of the connected GraphDB along
with the query that should be displayed in the Workbench, when the
``SPARQL`` button is pressed.
- Updated the related tests as well.
- Removed obsolite logic in the ``prepare-steps.ts``.