### PR TITLE
Sparql editor fixes

### DIFF
--- a/src/app/main/sparql-editor/sparql-editor.component.ts
+++ b/src/app/main/sparql-editor/sparql-editor.component.ts
@@ -18,6 +18,7 @@ import {SourceService} from 'src/app/services/source.service';
 import {RefineRepositoryService} from 'src/app/services/rest/refine-repository.service';
 import {EditorUtils} from './utils/editor-utils';
 import {CopyUtils} from './utils/copy-utils';
+import {ProjectInfo} from 'src/app/services/rest/rest.service';
 
 
 /**
@@ -143,10 +144,10 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
   /**
    * Initializes the configurations that is passed to the YASGUI editor.
    */
-  private initDefaultEditorConfiguration(info: any): void {
+  private initDefaultEditorConfiguration(info: ProjectInfo): void {
     this.config = {
       ...this.config,
-      endpoint: info.refineRepoUrl,
+      endpoint: info.refineRepoUrl.absolute,
       componentId: info.projectId,
     };
   }

--- a/src/app/main/sparql-editor/sparql-editor.component.ts
+++ b/src/app/main/sparql-editor/sparql-editor.component.ts
@@ -221,7 +221,7 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
 
     const areTabsDifferent = !this.compare(this.latestSavedEditorConfig.val.tabs, currentConfig.val.tabs);
     const isActiveTabConfigDifferent = !this.compare(latestActiveTabConfig, currentActiveTabConfig);
-    const areQueriesDifferent = latestActiveTabConfig.yasqe.value !== currentActiveTabConfig.yasqe.value;
+    const areQueriesDifferent = latestActiveTabConfig.yasqe?.value !== currentActiveTabConfig.yasqe?.value;
 
     if (areTabsDifferent || isActiveTabConfigDifferent || areQueriesDifferent) {
       this.messageService.publish(ChannelName.EditorConfigurationChanged);
@@ -327,6 +327,9 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
    * Handles the switching of the rendering mode of the editor.
    */
   private onRenderingModeSwitch(mode: RenderingMode): void {
+    if (mode !== RenderingMode.YASGUI) {
+      VisualizationUtils.toggleLayoutOrientation(this.editor.nativeElement, true);
+    }
     VisualizationUtils.changeRenderMode(this.editor.nativeElement, mode);
     this.messageService.publish(ChannelName.RenderingModeSwitched, mode);
   }
@@ -346,7 +349,7 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
    * query which will be appended to a URL leading to the connected GraphDB as query parameter.
    * The method will open the Workbench in new browser tab.
    */
-  private onOpenGdbWorkbench() {
+  private onOpenGdbWorkbench(): void {
     const sparql = this.getActiveTabConfig().yasqe.value;
     this.editorService.getGraphDbQueryUrl(this.tryToFormat(sparql))
         .pipe(untilComponentDestroyed(this))
@@ -361,7 +364,7 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
    * it is not updated when the editor content is edited.
    * The method updates the editor by replacing the entire query that is displayed.
    */
-  onColumnNameClick(source: Source) {
+  onColumnNameClick(source: Source): void {
     let sparql = this.getActiveTabConfig().yasqe.value;
 
     sparql = this.tryToFormat(sparql, true);
@@ -378,7 +381,7 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
    * Tries to format the query by using the static methods from the Yasqe object, which should be
    * available in the window object.
    */
-  private tryToFormat(sparql: string, notify: boolean = false) {
+  private tryToFormat(sparql: string, notify: boolean = false): string {
     // @ts-ignore
     if (!window.Yasgui && !this.unstableColumnsFuncWarnGiven) {
       if (notify) {
@@ -416,7 +419,7 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
    * The logic in the method relies that the query string will be formatted and in certain
    * situations where it is not, the logic may behave in a weird way.
    */
-  private calculateInsertionPosition(sparqlLines: string[], bracketsLevel: 1 | 2) {
+  private calculateInsertionPosition(sparqlLines: string[], bracketsLevel: 1 | 2): number {
     let currentBracketsLevel = 1;
     let position = 0;
     for (let i = sparqlLines.length - 1; i >= 0; i--) {

--- a/src/app/main/sparql-editor/sparql-editor.component.ts
+++ b/src/app/main/sparql-editor/sparql-editor.component.ts
@@ -210,6 +210,12 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
     }
 
     const activeTab = currentConfig.val.active;
+    const latestActiveTab = this.latestSavedEditorConfig.val.active;
+    if (activeTab !== latestActiveTab) {
+      this.messageService.publish(ChannelName.EditorConfigurationChanged);
+      return;
+    }
+
     const latestActiveTabConfig = this.latestSavedEditorConfig.val.tabConfig[activeTab];
     const currentActiveTabConfig = currentConfig.val.tabConfig[activeTab];
 

--- a/src/app/main/sparql-editor/utils/copy-utils.ts
+++ b/src/app/main/sparql-editor/utils/copy-utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Contains convenient logic for copying of objects.
+ *
+ * @author A. Kunchev
+ */
+export class CopyUtils {
+  /**
+   * Creates a shallow copy of the given object.
+   *
+   * @param object to copy
+   * @returns shallow copy of the input object
+   */
+  static spread<T>(object: T): T {
+    return object ? {...object} : object;
+  }
+
+  /**
+   * Creates a copy of the given value.
+   *
+   * @param value to copy
+   * @returns copy of the input value
+   */
+  static copy<T>(value: T): T {
+    if (!value) {
+      return value;
+    }
+    return structuredClone ? structuredClone(value) : JSON.parse(JSON.stringify(value));
+  }
+}

--- a/src/app/main/sparql-editor/utils/editor-utils.ts
+++ b/src/app/main/sparql-editor/utils/editor-utils.ts
@@ -24,6 +24,6 @@ export class EditorUtils {
 
     // @ts-ignore
     const activeQueryType: string = activeCmElement.CodeMirror.getQueryType();
-    return activeQueryType.toLowerCase() === type;
+    return activeQueryType && activeQueryType.toLowerCase() === type;
   }
 }

--- a/src/app/services/local-storage.service.ts
+++ b/src/app/services/local-storage.service.ts
@@ -1,6 +1,11 @@
 import {Injectable} from '@angular/core';
 
 export const STORAGE_CHANGE_EVENT_NAME = 'storage_change_event';
+export type ChangeEventDetails = {
+  key: string,
+  value?: any,
+  type: 'set' | 'remove'| 'clear'
+};
 
 /**
  * Service wrapping the Storage functionality. Additionally the service creates a Proxy over the
@@ -57,9 +62,10 @@ export class LocalStorageService {
   private proxySetItem(): void {
     Storage.prototype.setItem = new Proxy(Storage.prototype.setItem, {
       apply(target, thisArg, argumentList) {
-        const event = new CustomEvent(STORAGE_CHANGE_EVENT_NAME, {
+        const event = new CustomEvent<ChangeEventDetails>(STORAGE_CHANGE_EVENT_NAME, {
           detail: {
             key: argumentList[0],
+            value: argumentList[1],
             type: 'set',
           },
         });
@@ -72,7 +78,7 @@ export class LocalStorageService {
   private proxyRemoveItem(): void {
     Storage.prototype.removeItem = new Proxy(Storage.prototype.removeItem, {
       apply(target, thisArg, argumentList) {
-        const event = new CustomEvent(STORAGE_CHANGE_EVENT_NAME, {
+        const event = new CustomEvent<ChangeEventDetails>(STORAGE_CHANGE_EVENT_NAME, {
           detail: {
             key: argumentList[0],
             type: 'remove',
@@ -87,7 +93,7 @@ export class LocalStorageService {
   private proxyClear(): void {
     Storage.prototype.clear = new Proxy(Storage.prototype.clear, {
       apply(target, thisArg, argumentList) {
-        const event = new CustomEvent(STORAGE_CHANGE_EVENT_NAME, {
+        const event = new CustomEvent<ChangeEventDetails>(STORAGE_CHANGE_EVENT_NAME, {
           detail: {
             key: '__all__',
             type: 'clear',

--- a/src/app/services/rest/refine-repository.service.ts
+++ b/src/app/services/rest/refine-repository.service.ts
@@ -36,7 +36,7 @@ export class RefineRepositoryService extends RestService {
         },
         responseType: 'text' as 'text',
       };
-      return this.httpClient.post(data.refineRepoUrl, sparql, httpOpts)
+      return this.httpClient.post(data.refineRepoUrl.relative, sparql, httpOpts)
           .pipe(catchError((error) => {
             const msg = 'Failed to execute the provided query.';
             return this.errorReporterService.handleError(msg, error);

--- a/src/app/services/rest/rest.service.ts
+++ b/src/app/services/rest/rest.service.ts
@@ -4,17 +4,26 @@ import {ActivatedRoute, Params} from '@angular/router';
 import {Observable, of, EMPTY} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
+export type ProjectInfo = {
+  refineRepoUrl: {
+    relative: string,
+    absolute: string
+  },
+  project: string,
+  projectId: string
+};
+
 export class RestService {
   dataProviderID: Observable<string>;
   apiUrl = environment.restApiUrl;
 
-  private refineRepoUrl: string;
+  private refineRepoUrlConfig: string;
 
   constructor(protected route: ActivatedRoute) {
     this.dataProviderID = this.route.queryParams.pipe(switchMap((params: Params) => {
       return (params.dataProviderID) ? of(params.dataProviderID) : EMPTY;
     }));
-    this.refineRepoUrl = environment.refineVirtualRepositoryUrl;
+    this.refineRepoUrlConfig = environment.refineVirtualRepositoryUrl;
   }
 
   httpHeaders = new HttpHeaders({
@@ -36,14 +45,17 @@ export class RestService {
    * @param idPrefix prefix for the project identifier. It is required for the virtual repo URL
    * @returns observable object containing information about the current project
    */
-  getCurrentProjectInfo(): Observable<any> {
+  getCurrentProjectInfo(): Observable<ProjectInfo> {
     return this.dataProviderID.pipe(switchMap((dataProviderID) => {
       if (!dataProviderID) {
         return EMPTY;
       }
 
       return of({
-        refineRepoUrl: `${this.refineRepoUrl}${dataProviderID}`,
+        refineRepoUrl: {
+          relative: `${this.refineRepoUrlConfig}${dataProviderID}`,
+          absolute: `${location.origin}${this.refineRepoUrlConfig.substring(8)}${dataProviderID}`,
+        },
         project: dataProviderID,
         projectId: dataProviderID.split(':')[1],
       });


### PR DESCRIPTION
Fixes the calculation of the editor state for the save button

- Fixed the case where the user closes the current tab and the save
button does not detect that as a change.

  The issue is fixed by explicitly check the id of the currently active
tab and the cached id, used for the calculation function.

---
Fixes major issue related to calculation of the download button warn

- Fixed an issue, where in case the editor content is blank or does not
contain valid query, the entire view breaks.

  The fix consists in checking the result returned for the editor
content, before trying to process it.

---
Improves the SPARQL editor rendering and orientation behavior

- Now when the rendering mode is `editor only` or `results only` the
orientation will be switched to `horizontal` in order to take advantage
of the free space on the page.

---
Fixes yet another issue with the save button toggle on editor change

- Fixed an issue where the `save` button in the SPARLQ editor remains
inactive, if the user closes tab that is not currently active.

  The issue was related to comparison of stale editor configurations...

- Additionally, added utility class with common logic for objects
copying, because the JS objects references is still weird as f%^#!.

---
Fixes an issue related to Yasgui inability to work with relative URLs

- When the response from the execution of SPARQL query is too large for
Yasqe to render, it displays message in the area where the result table
should be.
  However, for some reason, while trying to display this message, the
logic tries to parse the provided URL for the SPARQL endpoint, which was
provided as relative path. That cause error to be thrown in the brower
console without any indication for it, which left the user with response
from the query that there are no results, which is inaccurate.

  So in order to fix the issue, the SPARQL endpoint was converted and
then provided as absolute URL to the Yasgui.