### PR TITLE
Adds Cypress tests for the SPARQL Query Editor and some improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # RDF Mapping UI Changelog
 
+## 2.1.0
+
+- Introduced SPARQL Query Editor based on the Yasgui.
+
 ## 2.0.0
 
 - Changed the default OntoRefine server port to 7333

--- a/cypress/fixtures/en.json
+++ b/cypress/fixtures/en.json
@@ -4,14 +4,27 @@
     "DOWNLOAD_JSON": "Download JSON",
     "RDF": "RDF",
     "SPARQL": "SPARQL",
-    "NEW": "New mapping",
+    "GDB_SPARQL": "Open in GraphDB",
+    "NEW": "New Mapping",
     "SAVE": "Save",
     "PREVIEW": "Preview",
     "OK": "Ok",
     "CANCEL": "Cancel",
     "CONFIGURATION": "Configuration",
     "PREVIEW_AND_CONFIGURATION": "Both",
-    "UPLOAD_JSON": "Upload JSON"
+    "UPLOAD_JSON": "Upload JSON",
+    "DOWNLOAD": "Download",
+    "QUERY": "Query",
+    "QUERY_WITH_SERVICE_CLAUSE": "Query with Service Clause",
+    "RESULT": "Result",
+    "GENERATE_QUERY": "Generate Query",
+    "YASGUI_EDITOR_ONLY": "Editor Only",
+    "YASGUI_EDITOR_AND_RESULTS": "Editor and Results",
+    "YASGUI_RESULTS_ONLY" : "Results Only",
+    "STANDARD_TEMPLATE": "Standard Template",
+    "SERVICE_CLAUSE_TEMPLATE": "Service Clause Template",
+    "FROM_MAPPING": "From Mapping",
+    "FROM_MAPPING_WITH_SERVICE_CLAUSE": "From Mapping with Service Clause"
   },
   "TOOLTIPS": {
     "SAVE_VALUE": "Save value",
@@ -36,7 +49,15 @@
     "UPLOAD_JSON": "Click to upload JSON mapping",
     "VIEW_MODE_CONFIGURATION": "Enable mapping configuration mode. Only configuration data will be visible.",
     "VIEW_MODE_PREVIEW": "Enable mapping preview mode. Only data preview will be visible.",
-    "VIEW_MODE_BOTH": "Enable mapping mixed config and preview mode. Both data preview and configurations will be visible."
+    "VIEW_MODE_BOTH": "Enable mapping mixed config and preview mode. Both data preview and configurations will be visible.",
+    "DOWNLOAD_SPARQL": "Download SPARQL query or results as a file",
+    "GENERATE_SPARQL": "Generate query in a new tab",
+    "YASGUI_SWITCH_ORIENTATION_HORIZONTAL": "Switch to horizontal view",
+    "YASGUI_SWITCH_ORIENTATION_VERTICAL": "Switch to vertical view",
+    "SAVE_EDITOR_CONFIG": "Save current editor configurations",
+    "OPEN_GDB_EDITOR": "Go to GraphDB Workbench",
+    "UNSAVED_MAPPING_CHANGES": "The are unsaved RDF mapping changes in the previous tab. The generated query will be based on the saved mapping.",
+    "DOWNLOAD_QUERY_RESULTS_INFO": "Download of results is available only for CONSTRUCT queries."
   },
   "LABELS": {
     "RDF_VALUE": "RDF value",
@@ -60,7 +81,9 @@
     "VALUE_BNODE": "BNode",
     "IRI": "IRI",
     "GREL": "GREL",
+    "RAW": "RAW",
     "GREL_PLACEHOLDER": "Use value, row, cell(s), recon, record",
+    "GREL_HINT": "E.g. cells[\"Website\"].value + \"/address\". Warning: column names are case sensitive.",
     "SUBJECT": "Subject RDF Value Mapping",
     "PREDICATE": "Predicate RDF Value Mapping",
     "OBJECT": "Object RDF Value Mapping",
@@ -91,7 +114,10 @@
     "INVALID_MAPPING_ERROR": "Invalid mapping. ",
     "UNRECOGNIZED_PREFIX_ERROR": "Unrecognized prefix.",
     "GREL_NO_PREVIEW": "No GREL preview",
-    "AUTOCOMPLETE_OFF_WARNING": "Autocomplete is OFF. Please, enable Autocomplete for this repository in GraphDB"
+    "AUTOCOMPLETE_OFF_WARNING": "Autocomplete is OFF. Please, enable Autocomplete for this repository in GraphDB",
+    "EDITOR_CONFIG_SAVED": "Current editor configuration was stored.",
+    "EDITOR_CONFIG_IS_DIRTY": "Editor has unsaved changes",
+    "EDITOR_CONFIG_IS_CLEAN": "All editor changes are saved"
   },
   "DIALOG": {
     "TITLE_CONFIRM": "Confirm",
@@ -106,7 +132,14 @@
     "REQUIRED": "* Required",
     "EMPTY_NAMESPACE": "* Namespace required",
     "COLON_NOT_ALLOWED": "* Colon is not allowed in prefix",
-    "MALFORMED_NAMESPACE": "* Malformed namespace"
+    "MALFORMED_NAMESPACE": "* Malformed namespace",
+    "NO_ACTIVE_EDITOR_TAB": "There is no active tab in the editor at the moment.",
+    "EDITOR_CONFIG_LOADING_FAILED": "Failed to load the editor configuration model.",
+    "NO_PROJECT_IDENTIFIER": "There is no project identifier. Try to refresh the project."
+  },
+  "WARNING": {
+    "UNAVAILABLE_YASGUI_INSTANCE": "There is an issue with the dataset columns functionality.\nThe behavior will be unstable.",
+    "DOWNLOAD_RESULT_AVAILABILITY": "Download of the results is available only for CONSTRUCT queries."
   },
   "TYPE": {
     "DATATYPE_LITERAL": "Datatype",
@@ -123,5 +156,10 @@
     "RAW": "Raw IRI",
     "GREL": "GREL",
     "A": "a"
+  },
+  "TABS": {
+    "RDF_MAPPER": "Visual RDF Mapper",
+    "SPARQL_EDITOR": "SPARQL Query Editor",
+    "GENERATED": "Generated"
   }
 }

--- a/cypress/fixtures/sparql-editor/default-sparql-with-service.txt
+++ b/cypress/fixtures/sparql-editor/default-sparql-with-service.txt
@@ -1,0 +1,7 @@
+BASE <http://example.com/base/>
+
+SELECT * WHERE {
+  SERVICE <http://localhost:4200/repositories/ontorefine:123> {
+    ?s ?p ?o .
+  }
+} LIMIT 100

--- a/cypress/fixtures/sparql-editor/default-sparql.txt
+++ b/cypress/fixtures/sparql-editor/default-sparql.txt
@@ -1,0 +1,5 @@
+BASE <http://example.com/base/>
+
+SELECT * WHERE {
+  ?s ?p ?o .
+} LIMIT 100

--- a/cypress/fixtures/sparql-editor/download-default-sparql-with-service.txt
+++ b/cypress/fixtures/sparql-editor/download-default-sparql-with-service.txt
@@ -1,0 +1,6 @@
+BASE <http://example.com/base/>
+SELECT * WHERE {
+  SERVICE <http://localhost:4200/repositories/ontorefine:123> {
+    ?s ?p ?o .
+  }
+} LIMIT 100

--- a/cypress/fixtures/sparql-editor/download-default-sparql.txt
+++ b/cypress/fixtures/sparql-editor/download-default-sparql.txt
@@ -1,0 +1,4 @@
+BASE <http://example.com/base/>
+SELECT * WHERE {
+  ?s ?p ?o .
+} LIMIT 100

--- a/cypress/fixtures/sparql-editor/download-query-results.ttl
+++ b/cypress/fixtures/sparql-editor/download-query-results.ttl
@@ -1,0 +1,725 @@
+<http://example.com/base/subject> <http://example.com/base/name> "Smits Noord-Zuid Hollandsch Koffiehuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Afrikaans Restaurant Kilimanjaro" .
+<http://example.com/base/subject> <http://example.com/base/name> "Akbar Indian Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Alfonso's Mexican Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café het Paleis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Amstel Bar & Brasserie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Caffe Ristretto - Lunchrestaurant & Café" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Restaurant de Passage" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Stijl" .
+<http://example.com/base/subject> <http://example.com/base/name> "Cinema Paradiso" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Bijenkorf Kitchen" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Kroonprins" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Indrapura" .
+<http://example.com/base/subject> <http://example.com/base/name> "D'Vijf Broers" .
+<http://example.com/base/subject> <http://example.com/base/name> "Madre Maria" .
+<http://example.com/base/subject> <http://example.com/base/name> "Matias" .
+<http://example.com/base/subject> <http://example.com/base/name> "Girassol" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Majestic" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Mercure Amsterdam Airport" .
+<http://example.com/base/subject> <http://example.com/base/name> "Palazzo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Panagia" .
+<http://example.com/base/subject> <http://example.com/base/name> "Patisserie Pompadour" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rain Restaurant Bar Club" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Neva" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Syriana" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rose's Cantina" .
+<http://example.com/base/subject> <http://example.com/base/name> "Tempo Doeloe" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant The College Hotel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Small Talk Restaurant en Coffee Corner" .
+<http://example.com/base/subject> <http://example.com/base/name> "VAKZUID" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hotel Arena - Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Indonesisch Restaurant Sama Sebo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Koh-I-Noor Rokin" .
+<http://example.com/base/subject> <http://example.com/base/name> "Koh-I-Noor Westermarkt" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Madonnina" .
+<http://example.com/base/subject> <http://example.com/base/name> "Little Buddha Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grill Steak House Maya" .
+<http://example.com/base/subject> <http://example.com/base/name> "Van der Valk Hotel Almere" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Hart van Weesp" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hotel Restaurant Het Rechthuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Apollo Hotel Lelystad" .
+<http://example.com/base/subject> <http://example.com/base/name> "Buitenhuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant L'Hirondelle" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant De Wintertuin" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Het Oude Dykhuys" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Gusto" .
+<http://example.com/base/subject> <http://example.com/base/name> "Japans Restaurant Senbazuru" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pancho's Cantina" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Brasserie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Wapen van Aalsmeer" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant BoatHouse" .
+<http://example.com/base/subject> <http://example.com/base/name> "Oude Molen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant de Waegh" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Het Oude Spoorhuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Grand Cafe Applaus" .
+<http://example.com/base/subject> <http://example.com/base/name> "Villa Westend" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Heerenhuis Beemster" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lounge-Bar-Restaurant  &quot:Vijf&quot:" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie DenK" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant 't Dijkhuysje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bar & Restaurant Puur Saen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant De Gier & De Krijger" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Vrienden van Jacob" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Wapen van Assendelft" .
+<http://example.com/base/subject> <http://example.com/base/name> "Steiger 28" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant De Halve Maen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Himalaya Huis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Tokyo Cafe" .
+<http://example.com/base/subject> <http://example.com/base/name> "Tandoor Indian Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lef uit + eten" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Wegwijzer" .
+<http://example.com/base/subject> <http://example.com/base/name> "A la Ferme" .
+<http://example.com/base/subject> <http://example.com/base/name> "A Tavola" .
+<http://example.com/base/subject> <http://example.com/base/name> "Affourtit" .
+<http://example.com/base/subject> <http://example.com/base/name> "Amstelhaven" .
+<http://example.com/base/subject> <http://example.com/base/name> "restaurant BIHP" .
+<http://example.com/base/subject> <http://example.com/base/name> "Arc - tijdelijk gesloten" .
+<http://example.com/base/subject> <http://example.com/base/name> "As" .
+<http://example.com/base/subject> <http://example.com/base/name> "Assagi" .
+<http://example.com/base/subject> <http://example.com/base/name> "Balthazar's Keuken" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bar Waldorf" .
+<http://example.com/base/subject> <http://example.com/base/name> "Beddington's" .
+<http://example.com/base/subject> <http://example.com/base/name> "Blok 4" .
+<http://example.com/base/subject> <http://example.com/base/name> "Beulings" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bicken" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bickers a/d Werf" .
+<http://example.com/base/subject> <http://example.com/base/name> "Blauw" .
+<http://example.com/base/subject> <http://example.com/base/name> "Blauw aan de Wal" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bloem op IJburg" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bloesem" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bond" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bordewijk" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grand-Café - Brasserie Maximiliaan" .
+<http://example.com/base/subject> <http://example.com/base/name> "Burgers Patio" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café George" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Restaurant Edel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Casa di David" .
+<http://example.com/base/subject> <http://example.com/base/name> "Casa Peru" .
+<http://example.com/base/subject> <http://example.com/base/name> "Cedars" .
+<http://example.com/base/subject> <http://example.com/base/name> "Chang-I" .
+<http://example.com/base/subject> <http://example.com/base/name> "Chocolate Bar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ciel Bleu" .
+<http://example.com/base/subject> <http://example.com/base/name> "D'Antica" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dauphine" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Belhamel" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Cantine" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Luwte" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Pont" .
+<http://example.com/base/subject> <http://example.com/base/name> "Drink & Eetlokaal Het Schoolhuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dynasty" .
+<http://example.com/base/subject> <http://example.com/base/name> "Envy" .
+<http://example.com/base/subject> <http://example.com/base/name> "Fa. Pekelhaaring" .
+<http://example.com/base/subject> <http://example.com/base/name> "Gauchos Beethovenstraat" .
+<http://example.com/base/subject> <http://example.com/base/name> "Freud" .
+<http://example.com/base/subject> <http://example.com/base/name> "FLO Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hemelse Modder" .
+<http://example.com/base/subject> <http://example.com/base/name> "Herengracht" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hostaria" .
+<http://example.com/base/subject> <http://example.com/base/name> "Incanto" .
+<http://example.com/base/subject> <http://example.com/base/name> "Italiaans Restaurant Pizzeria Pepe" .
+<http://example.com/base/subject> <http://example.com/base/name> "Kantjil en de tijger" .
+<http://example.com/base/subject> <http://example.com/base/name> "Klokspijs" .
+<http://example.com/base/subject> <http://example.com/base/name> "Koevoet" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Oliva" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Rive" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Vallade" .
+<http://example.com/base/subject> <http://example.com/base/name> "Le Hollandais" .
+<http://example.com/base/subject> <http://example.com/base/name> "Le Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lof" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Looks" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mamouche" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mantoe" .
+<http://example.com/base/subject> <http://example.com/base/name> "Marius" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mashua" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mayur" .
+<http://example.com/base/subject> <http://example.com/base/name> "Meghna" .
+<http://example.com/base/subject> <http://example.com/base/name> "Momo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Nassau" .
+<http://example.com/base/subject> <http://example.com/base/name> "New Dorrius" .
+<http://example.com/base/subject> <http://example.com/base/name> "Nomads ** GESLOTEN" .
+<http://example.com/base/subject> <http://example.com/base/name> "Orbit" .
+<http://example.com/base/subject> <http://example.com/base/name> "P.King" .
+<http://example.com/base/subject> <http://example.com/base/name> "Peper & Zout" .
+<http://example.com/base/subject> <http://example.com/base/name> "Kapitein Zeppos" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ponte Arcari" .
+<http://example.com/base/subject> <http://example.com/base/name> "Prego" .
+<http://example.com/base/subject> <http://example.com/base/name> "Quattro Gatti" .
+<http://example.com/base/subject> <http://example.com/base/name> "Raïnaraï" .
+<http://example.com/base/subject> <http://example.com/base/name> "Red" .
+<http://example.com/base/subject> <http://example.com/base/name> "Seven seas" .
+<http://example.com/base/subject> <http://example.com/base/name> "Simpel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sing Sing" .
+<http://example.com/base/subject> <http://example.com/base/name> "Spanjer en van Twist" .
+<http://example.com/base/subject> <http://example.com/base/name> "Stanislavski" .
+<http://example.com/base/subject> <http://example.com/base/name> "Take Thai" .
+<http://example.com/base/subject> <http://example.com/base/name> "Thai & Co" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Colour Kitchen" .
+<http://example.com/base/subject> <http://example.com/base/name> "The French Cafe" .
+<http://example.com/base/subject> <http://example.com/base/name> "The White Elephant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Toscanini" .
+<http://example.com/base/subject> <http://example.com/base/name> "Trattoria de Donna Sofia" .
+<http://example.com/base/subject> <http://example.com/base/name> "Van Harte" .
+<http://example.com/base/subject> <http://example.com/base/name> "Van Puffelen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vapiano" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vasso" .
+<http://example.com/base/subject> <http://example.com/base/name> "Villa Nieuwmarkt" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vinkeles" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vis aan de Schelde" .
+<http://example.com/base/subject> <http://example.com/base/name> "Winkel 43" .
+<http://example.com/base/subject> <http://example.com/base/name> "Yam Yam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Yamazato" .
+<http://example.com/base/subject> <http://example.com/base/name> "Zabayon" .
+<http://example.com/base/subject> <http://example.com/base/name> "Zen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Van De Kaart" .
+<http://example.com/base/subject> <http://example.com/base/name> "Stout!" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Kraai" .
+<http://example.com/base/subject> <http://example.com/base/name> "Yoshi Yoshi" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Keuken van Von" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Tolhuys aan de Zaan" .
+<http://example.com/base/subject> <http://example.com/base/name> "I Gemelli" .
+<http://example.com/base/subject> <http://example.com/base/name> "Da Marcello" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Liefde" .
+<http://example.com/base/subject> <http://example.com/base/name> "Revan" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Ponteneur" .
+<http://example.com/base/subject> <http://example.com/base/name> "Senses" .
+<http://example.com/base/subject> <http://example.com/base/name> "The ART Brasserie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Flinders Café" .
+<http://example.com/base/subject> <http://example.com/base/name> "Gollem's Proeflokaal" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mata Hari" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grandcafe 3&20" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grolsch Cinecafe" .
+<http://example.com/base/subject> <http://example.com/base/name> "A La Ferme" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wissenkerke Sloterdijk" .
+<http://example.com/base/subject> <http://example.com/base/name> "Zazas" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bridges" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ron Gastrobar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Assaggi" .
+<http://example.com/base/subject> <http://example.com/base/name> "East57" .
+<http://example.com/base/subject> <http://example.com/base/name> "Scossa" .
+<http://example.com/base/subject> <http://example.com/base/name> "Barra" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bord'Eau" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Pica Pica" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Kersentuin" .
+<http://example.com/base/subject> <http://example.com/base/name> "Voyager (Sheraton Schiphol)" .
+<http://example.com/base/subject> <http://example.com/base/name> "Aan de Poel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Tanuki" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Jagershuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Broeker Huis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Akitsu" .
+<http://example.com/base/subject> <http://example.com/base/name> "New King" .
+<http://example.com/base/subject> <http://example.com/base/name> "Foodware" .
+<http://example.com/base/subject> <http://example.com/base/name> "Los Pilones" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant de Struisvogel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Jaspers" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Greetje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Le Zinc et les Autres" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hap-Hmm" .
+<http://example.com/base/subject> <http://example.com/base/name> "Stamppotje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Bloemers" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Eetkamer van de Jordaan" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Knijp" .
+<http://example.com/base/subject> <http://example.com/base/name> "Izakaya" .
+<http://example.com/base/subject> <http://example.com/base/name> "Nepalese Restaurant Mt. Everest" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie Café Oevers" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant De Chinese Muur" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant De Vier Seizoenen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Strandpaviljoen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Thais Restaurant LemonLeaf" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mykonos" .
+<http://example.com/base/subject> <http://example.com/base/name> "NRC Restaurant Café" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Vandaag" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Bonsai" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pannenkoekenboerderij Onder Plantanen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lastage" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Vermeer" .
+<http://example.com/base/subject> <http://example.com/base/name> "Uit de Keuken" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het wapen van Middelie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Saskia?s huiskamerrestaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Caro Kookt" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eten bij mij" .
+<http://example.com/base/subject> <http://example.com/base/name> "Marits huiskamerrestaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Marleen kookt" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sla" .
+<http://example.com/base/subject> <http://example.com/base/name> "Julius Bar&Grill" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Dutch Co." .
+<http://example.com/base/subject> <http://example.com/base/name> "De IJ-keuken" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Uitvreter" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Stedelijk" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grand Cafe Il Gusto Ristorante" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vondelpark3" .
+<http://example.com/base/subject> <http://example.com/base/name> "Greenwoods" .
+<http://example.com/base/subject> <http://example.com/base/name> "Omelegg" .
+<http://example.com/base/subject> <http://example.com/base/name> "Trust" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dijkers eten & drinken" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Vier Seizoenen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Orangerie Elswout" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Mastenbar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sazanka" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Sinne" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pho 91" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vinnies" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Gastro.bar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Salsa Shop" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie Nacional" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pata Negra" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie Bark" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Silveren Spiegel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bar Brandstof" .
+<http://example.com/base/subject> <http://example.com/base/name> "BUFFET van Odette" .
+<http://example.com/base/subject> <http://example.com/base/name> "Maslow" .
+<http://example.com/base/subject> <http://example.com/base/name> "THT" .
+<http://example.com/base/subject> <http://example.com/base/name> "T eten & drinken" .
+<http://example.com/base/subject> <http://example.com/base/name> "STEK" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Spelt" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bojo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rijsel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rosa & Rita" .
+<http://example.com/base/subject> <http://example.com/base/name> "63graden Foodbar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Morlang" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Red" .
+<http://example.com/base/subject> <http://example.com/base/name> "Aan de Amstel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lazagne" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Ysbreeker" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hummbar" .
+<http://example.com/base/subject> <http://example.com/base/name> "BAUT Zuid" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Fat Dog" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant As" .
+<http://example.com/base/subject> <http://example.com/base/name> "Instock" .
+<http://example.com/base/subject> <http://example.com/base/name> "Little Collins" .
+<http://example.com/base/subject> <http://example.com/base/name> "Citroën Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mother India" .
+<http://example.com/base/subject> <http://example.com/base/name> "Voldaan" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pinxobar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Kiebêrt" .
+<http://example.com/base/subject> <http://example.com/base/name> "BAK" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hendrix" .
+<http://example.com/base/subject> <http://example.com/base/name> "MOS Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dophert" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vijfnulvijf" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Modern" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bistro Zuidlande" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ron Gastrobar Oriental" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Harbour Club Kitchen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Terpentijn" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hannekes Boom" .
+<http://example.com/base/subject> <http://example.com/base/name> "DWDD pop-up restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Pantry" .
+<http://example.com/base/subject> <http://example.com/base/name> "Gustafson Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lion Noir" .
+<http://example.com/base/subject> <http://example.com/base/name> "Guts & Glory" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rolling Rock Kitchen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Roomservice at Olof's" .
+<http://example.com/base/subject> <http://example.com/base/name> "Kaagman & Kortekaas" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mossel & Gin" .
+<http://example.com/base/subject> <http://example.com/base/name> "Moon" .
+<http://example.com/base/subject> <http://example.com/base/name> "Fou Fow Ramen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hummus Bistro d&a" .
+<http://example.com/base/subject> <http://example.com/base/name> "Zouthaven" .
+<http://example.com/base/subject> <http://example.com/base/name> "Waterkant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Castell" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café DS" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eastside Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ibis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant CHI" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Bidou" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mozo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Nam Kee" .
+<http://example.com/base/subject> <http://example.com/base/name> "Huis aan de Amstel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Thrill Grill" .
+<http://example.com/base/subject> <http://example.com/base/name> "Geflipt" .
+<http://example.com/base/subject> <http://example.com/base/name> "Burgerbar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Cannibale Royale" .
+<http://example.com/base/subject> <http://example.com/base/name> "Frits" .
+<http://example.com/base/subject> <http://example.com/base/name> "World of Food" .
+<http://example.com/base/subject> <http://example.com/base/name> "Breda" .
+<http://example.com/base/subject> <http://example.com/base/name> "SNCKBR" .
+<http://example.com/base/subject> <http://example.com/base/name> "Jansz" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant DS" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bar Basquiat" .
+<http://example.com/base/subject> <http://example.com/base/name> "Supermercado" .
+<http://example.com/base/subject> <http://example.com/base/name> "ICHI-E" .
+<http://example.com/base/subject> <http://example.com/base/name> "Badhuis Javaplein" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Japanner" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Heerenhuis Beemster(kopie)" .
+<http://example.com/base/subject> <http://example.com/base/name> "Janz." .
+<http://example.com/base/subject> <http://example.com/base/name> "Mchi Mood Food & Drinks" .
+<http://example.com/base/subject> <http://example.com/base/name> "Van 't Spit" .
+<http://example.com/base/subject> <http://example.com/base/name> "DIS" .
+<http://example.com/base/subject> <http://example.com/base/name> "Braai" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bajesdorp" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bistro Baret" .
+<http://example.com/base/subject> <http://example.com/base/name> "Happyhappyjoyjoy East" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Gerard van Es" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lute" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eat Your Heart Out" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Pool" .
+<http://example.com/base/subject> <http://example.com/base/name> "John Dory" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Meets" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hangar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pension Homeland" .
+<http://example.com/base/subject> <http://example.com/base/name> "Louie Louie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dok" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bo Cinq" .
+<http://example.com/base/subject> <http://example.com/base/name> "Snappers" .
+<http://example.com/base/subject> <http://example.com/base/name> "Luitenant Cornelis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Vissershaven - andere eigenaar (input komt nog)" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wilde Westen Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Magnolia's Hampshire Golfhotel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Taqueria Tacobar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café de Paris" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Seafood Market" .
+<http://example.com/base/subject> <http://example.com/base/name> "Meneer Nieges" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Cantinetta Wine&Pasta" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ctaste - Dining in the dark" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Partycentrum De Jagersplas" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grand Café Hannes" .
+<http://example.com/base/subject> <http://example.com/base/name> "Strandzuid" .
+<http://example.com/base/subject> <http://example.com/base/name> "CornelisZ" .
+<http://example.com/base/subject> <http://example.com/base/name> "REM Eiland" .
+<http://example.com/base/subject> <http://example.com/base/name> "Razmataz" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant C" .
+<http://example.com/base/subject> <http://example.com/base/name> "Smokin' Barrels" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Panache" .
+<http://example.com/base/subject> <http://example.com/base/name> "Happyhappyjoyjoy West" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Rotisserie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Spaghetteria" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Brooklyn" .
+<http://example.com/base/subject> <http://example.com/base/name> "Peperwortel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café-restaurant De Plantage" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grand café de Tropen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hotel de Goudfazant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Noara's Restaurant en Lounge" .
+<http://example.com/base/subject> <http://example.com/base/name> "Elkaar" .
+<http://example.com/base/subject> <http://example.com/base/name> "Il Pecorino" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie Nobel" .
+<http://example.com/base/subject> <http://example.com/base/name> "GIN Neo Bistro & Wines(kopie)" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Butcher" .
+<http://example.com/base/subject> <http://example.com/base/name> "CT Coffee & Coconuts" .
+<http://example.com/base/subject> <http://example.com/base/name> "manamana" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dim Sum Now" .
+<http://example.com/base/subject> <http://example.com/base/name> "Calle Ocho" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant van den Hogen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Havenrestaurant De Lunch" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mr Porter" .
+<http://example.com/base/subject> <http://example.com/base/name> "Carter Bar & Kitchen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Renato's Osteria" .
+<http://example.com/base/subject> <http://example.com/base/name> "Oma Ietje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pont 13" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant 1e Klas & 1e Klas Pub" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Jopenkerk" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Verkeerde Wereld" .
+<http://example.com/base/subject> <http://example.com/base/name> "Testrestaurant Kristel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Gin Neo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Herberg Hooghoudt" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Blue" .
+<http://example.com/base/subject> <http://example.com/base/name> "Van der Valk Hotel Volendam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hof van Holland" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant IJmond" .
+<http://example.com/base/subject> <http://example.com/base/name> "Healthfood Restaurant De Bolhoed" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Italiaan" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Het Veerhuys" .
+<http://example.com/base/subject> <http://example.com/base/name> "Betty's" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bar James" .
+<http://example.com/base/subject> <http://example.com/base/name> "Westeinder Paviljoen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Nevel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Thijs" .
+<http://example.com/base/subject> <http://example.com/base/name> "Meatless District" .
+<http://example.com/base/subject> <http://example.com/base/name> "YAY Health Store & More" .
+<http://example.com/base/subject> <http://example.com/base/name> "Samhoud Places" .
+<http://example.com/base/subject> <http://example.com/base/name> "Stork" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rotisserie East" .
+<http://example.com/base/subject> <http://example.com/base/name> "Seafood Bar Van Baerlestraat" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bistro Belle" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mazzo" .
+<http://example.com/base/subject> <http://example.com/base/name> "DeShima" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mystique" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lotti's Bar and Grill" .
+<http://example.com/base/subject> <http://example.com/base/name> "Merkelbach" .
+<http://example.com/base/subject> <http://example.com/base/name> "TonTon Club Westergasfabriek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Toko Boemboe Bali" .
+<http://example.com/base/subject> <http://example.com/base/name> "NaangNuan" .
+<http://example.com/base/subject> <http://example.com/base/name> "Los del Puerto" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Four Seasons" .
+<http://example.com/base/subject> <http://example.com/base/name> "Graham's Kitchen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hoofdstad Brasserie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Meneer De Wit Heeft Honger" .
+<http://example.com/base/subject> <http://example.com/base/name> "Yokiyo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Visbar Beet" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wolf Atelier" .
+<http://example.com/base/subject> <http://example.com/base/name> "Burgermeester" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Kleine Valk" .
+<http://example.com/base/subject> <http://example.com/base/name> "Librije?s Zusje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ter Marsch & Co" .
+<http://example.com/base/subject> <http://example.com/base/name> "Saravana Bhavan" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Zwaantje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Al Argentino Restaurant Steakhouse" .
+<http://example.com/base/subject> <http://example.com/base/name> "Graceland BAR-B-Q" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie van Baerle" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Lieve" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Fabriek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bulls and Dogs" .
+<http://example.com/base/subject> <http://example.com/base/name> "Suitehotel | Restaurant Posthoorn" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Odessa" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Fish Toko" .
+<http://example.com/base/subject> <http://example.com/base/name> "NEST" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Culinaire Werkplaats" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Hoop Op d'Swarte Walvis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Casablanca Variété" .
+<http://example.com/base/subject> <http://example.com/base/name> "Da Portare Via" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Pannekoekkelder" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant & Brasserie Luden" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant De Kas" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant d'Vijff Vlieghen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Haesje Claes" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lucius Visrestaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Fifteen Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Moeders" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Los Argentinos" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pasta e Basta" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vegetarisch Restaurant De Waaghals" .
+<http://example.com/base/subject> <http://example.com/base/name> "Guadalupe" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hard Rock Cafe Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Humphrey's" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Madonna" .
+<http://example.com/base/subject> <http://example.com/base/name> "Le Rendez-Vous" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café-Restaurant Land en Zeezicht" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant De Vijfde Smaak" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Koperen Bel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rancho Argentinian Grill" .
+<http://example.com/base/subject> <http://example.com/base/name> "Le Garage" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Kop van Haven" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Dolce Vita" .
+<http://example.com/base/subject> <http://example.com/base/name> "NeL" .
+<http://example.com/base/subject> <http://example.com/base/name> "Old School" .
+<http://example.com/base/subject> <http://example.com/base/name> "Flair Culinair Cook & Dine Concept" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Cage Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Puri Mas" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant-Café In de Waag" .
+<http://example.com/base/subject> <http://example.com/base/name> "Supperclub" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Nieuwe Kafe Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sea Palace" .
+<http://example.com/base/subject> <http://example.com/base/name> "St. George" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bazar Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Noordwest" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant WestergasTerras" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wagamama Max Euweplein" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wagamama Rembrandtplein" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wagamama Centraal" .
+<http://example.com/base/subject> <http://example.com/base/name> "NEIGHBOURS" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Villa Maria" .
+<http://example.com/base/subject> <http://example.com/base/name> "Toro Dorado Quality Steaks" .
+<http://example.com/base/subject> <http://example.com/base/name> "Herberg De Compagnie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Cafe Collette" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mr. & Mrs." .
+<http://example.com/base/subject> <http://example.com/base/name> "Specktakel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Staal" .
+<http://example.com/base/subject> <http://example.com/base/name> "Table 24" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Louisiana" .
+<http://example.com/base/subject> <http://example.com/base/name> "Truffels" .
+<http://example.com/base/subject> <http://example.com/base/name> "Blue Pepper" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Happy Pig Pancake Shop" .
+<http://example.com/base/subject> <http://example.com/base/name> "'t Heerenhuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Jacobsz" .
+<http://example.com/base/subject> <http://example.com/base/name> "Swych" .
+<http://example.com/base/subject> <http://example.com/base/name> "Auberge Jean & Marie" .
+<http://example.com/base/subject> <http://example.com/base/name> "L ?invite le Restaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Restaurant Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Taiko" .
+<http://example.com/base/subject> <http://example.com/base/name> "Oriental City" .
+<http://example.com/base/subject> <http://example.com/base/name> "Goodies" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Falote" .
+<http://example.com/base/subject> <http://example.com/base/name> "La Perla" .
+<http://example.com/base/subject> <http://example.com/base/name> "The White Room" .
+<http://example.com/base/subject> <http://example.com/base/name> "Scheepskameel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Salsa Shop CS" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ramses" .
+<http://example.com/base/subject> <http://example.com/base/name> "Huis van Lopez" .
+<http://example.com/base/subject> <http://example.com/base/name> "Salmuera" .
+<http://example.com/base/subject> <http://example.com/base/name> "Conservatorium Brasserie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Chiapas Taco Kartel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Poké Perfect" .
+<http://example.com/base/subject> <http://example.com/base/name> "Skek" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Pizzabakkers" .
+<http://example.com/base/subject> <http://example.com/base/name> "Adam & Siam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Tunes Restaurant and Bar by Schilo" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Boffert familierestaurant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vuurtoreneiland" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant VandeMarkt & Wine Wijn" .
+<http://example.com/base/subject> <http://example.com/base/name> "Midtown grill" .
+<http://example.com/base/subject> <http://example.com/base/name> "Kookerij de Singel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bistro Bij Ons" .
+<http://example.com/base/subject> <http://example.com/base/name> "'t Beemster Spijshuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wilde Zwijnen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Restaurant Classico" .
+<http://example.com/base/subject> <http://example.com/base/name> "IJ-Kantine" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Blauwe Theehuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café het Paleis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Schiller" .
+<http://example.com/base/subject> <http://example.com/base/name> "Caffe Ristretto - Lunchrestaurant & Café" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eet- en Bierencafé De Beiaard" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Restaurant de Passage" .
+<http://example.com/base/subject> <http://example.com/base/name> "KinderkookKafé" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eetcafé de Zeilhoek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bloem" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café 't Blaauwhooft" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café De Pijp" .
+<http://example.com/base/subject> <http://example.com/base/name> "Caffe Milo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Caffe Oslo" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Smoeshaan" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Toog" .
+<http://example.com/base/subject> <http://example.com/base/name> "Festina Lente" .
+<http://example.com/base/subject> <http://example.com/base/name> "Golden Brown" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dulac" .
+<http://example.com/base/subject> <http://example.com/base/name> "Langendijk" .
+<http://example.com/base/subject> <http://example.com/base/name> "Fidelio" .
+<http://example.com/base/subject> <http://example.com/base/name> "Louter" .
+<http://example.com/base/subject> <http://example.com/base/name> "Polder" .
+<http://example.com/base/subject> <http://example.com/base/name> "Luxembourg" .
+<http://example.com/base/subject> <http://example.com/base/name> "Wilhelmina Dok" .
+<http://example.com/base/subject> <http://example.com/base/name> "'t Kalfje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eetcafé - jachthaven 't Swaentje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grand Cafe Batavia" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sarphaat" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Marie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Groot Melkhuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eetcafé de Jachtclub" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bar Spek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eetcafé de Oude School" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vondeltuin" .
+<http://example.com/base/subject> <http://example.com/base/name> "Anne&Max" .
+<http://example.com/base/subject> <http://example.com/base/name> "Moods Coffee Corner" .
+<http://example.com/base/subject> <http://example.com/base/name> "Toastable" .
+<http://example.com/base/subject> <http://example.com/base/name> "Roots" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Maxwell" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Loetje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bar Baarsch" .
+<http://example.com/base/subject> <http://example.com/base/name> "Gent aan de Schinkel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Testrestaurant Kristel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Viscafe de Gouden Hoek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Marker Veerhuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Koperen Vis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Grand Café Amstelhoeck" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie Harkema (GESLOTEN)" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Prins" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Fabriek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hoi" .
+<http://example.com/base/subject> <http://example.com/base/name> "Taverne De Visscher" .
+<http://example.com/base/subject> <http://example.com/base/name> "Café Lennep" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pannekoekschip Wormerveer" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Zaanse pannenkoekenpaleis" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Pannenkoekenhoek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pannekoekenpaviljoen De Carrousel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pannenkoekenboot" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pancakes! Prins Hendrikkade" .
+<http://example.com/base/subject> <http://example.com/base/name> "Testrestaurant Kristel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pannenkoekenhuis De Witte Swaen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pancakes! Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Pancake Bakery" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mook Pancakes" .
+<http://example.com/base/subject> <http://example.com/base/name> "'t Beemster Spijshuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Paviljoen Noordzee" .
+<http://example.com/base/subject> <http://example.com/base/name> "Paviljoen Zeezicht" .
+<http://example.com/base/subject> <http://example.com/base/name> "Paviljoen Nova Zembla" .
+<http://example.com/base/subject> <http://example.com/base/name> "Zandvoort Beach Clubs" .
+<http://example.com/base/subject> <http://example.com/base/name> "Woodstock 69" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bloomingdale" .
+<http://example.com/base/subject> <http://example.com/base/name> "Fuel" .
+<http://example.com/base/subject> <http://example.com/base/name> "San Blas" .
+<http://example.com/base/subject> <http://example.com/base/name> "Republiek Bloemendaal" .
+<http://example.com/base/subject> <http://example.com/base/name> "Havana" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mango?s Beach Bar" .
+<http://example.com/base/subject> <http://example.com/base/name> "George No 5 ? Mer du Nord" .
+<http://example.com/base/subject> <http://example.com/base/name> "Safari Club" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sandy Hill" .
+<http://example.com/base/subject> <http://example.com/base/name> "Skyline & First Wave" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vooges" .
+<http://example.com/base/subject> <http://example.com/base/name> "Zout" .
+<http://example.com/base/subject> <http://example.com/base/name> "Ajuma" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rapa Nui" .
+<http://example.com/base/subject> <http://example.com/base/name> "Tent 6" .
+<http://example.com/base/subject> <http://example.com/base/name> "Tijn Akersloot" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Spot" .
+<http://example.com/base/subject> <http://example.com/base/name> "Aloha Beach" .
+<http://example.com/base/subject> <http://example.com/base/name> "Zilt aan zee" .
+<http://example.com/base/subject> <http://example.com/base/name> "Beach Club Far Out" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Haven van Zandvoort" .
+<http://example.com/base/subject> <http://example.com/base/name> "Testrestaurant Kristel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Beach Inn" .
+<http://example.com/base/subject> <http://example.com/base/name> "Strandpaviljoen Timboektoe" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vroeger" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eetsalon van Dobben de Pijp" .
+<http://example.com/base/subject> <http://example.com/base/name> "Cora Delicatessen & Broodjes" .
+<http://example.com/base/subject> <http://example.com/base/name> "Jonk Haringhandel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Vlaamsch Broodhuys" .
+<http://example.com/base/subject> <http://example.com/base/name> "Koffiehuis De Hoek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Eetsalon van Dobben B.V." .
+<http://example.com/base/subject> <http://example.com/base/name> "Het wapen van Middelie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Häagen-Dazs IJssalon" .
+<http://example.com/base/subject> <http://example.com/base/name> "Frozen Yoghurt Company" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het IJspaleis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Mezzo ijssalon en lunchroom" .
+<http://example.com/base/subject> <http://example.com/base/name> "Jordino" .
+<http://example.com/base/subject> <http://example.com/base/name> "Koel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lanskroon" .
+<http://example.com/base/subject> <http://example.com/base/name> "Monte Pelmo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pisa IJs" .
+<http://example.com/base/subject> <http://example.com/base/name> "Venetië IJs" .
+<http://example.com/base/subject> <http://example.com/base/name> "IJscuypje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Metropolitan" .
+<http://example.com/base/subject> <http://example.com/base/name> "IJsboutique" .
+<http://example.com/base/subject> <http://example.com/base/name> "Frozz" .
+<http://example.com/base/subject> <http://example.com/base/name> "Theehuis Cruquius" .
+<http://example.com/base/subject> <http://example.com/base/name> "Harar Coffee" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het Weeshuis" .
+<http://example.com/base/subject> <http://example.com/base/name> "Theetuin en Fluisterbootverhuur Overleek" .
+<http://example.com/base/subject> <http://example.com/base/name> "Het wapen van Middelie" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Verkeerde Wereld" .
+<http://example.com/base/subject> <http://example.com/base/name> "Toko Boemboe Bali" .
+<http://example.com/base/subject> <http://example.com/base/name> "Latei" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lunchroom Ab Müller" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Koffiezaak" .
+<http://example.com/base/subject> <http://example.com/base/name> "Brasserie Bel Ami" .
+<http://example.com/base/subject> <http://example.com/base/name> "Gartine" .
+<http://example.com/base/subject> <http://example.com/base/name> "Boterham" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bakers & Roasters" .
+<http://example.com/base/subject> <http://example.com/base/name> "LAVINIA Good Food" .
+<http://example.com/base/subject> <http://example.com/base/name> "Venkel Salades" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sugarless" .
+<http://example.com/base/subject> <http://example.com/base/name> "Petit Gâteau" .
+<http://example.com/base/subject> <http://example.com/base/name> "Scandinavian Embassy" .
+<http://example.com/base/subject> <http://example.com/base/name> "Hofje zonder Zorgen" .
+<http://example.com/base/subject> <http://example.com/base/name> "Sugar & Spice" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lebkov & Sons" .
+<http://example.com/base/subject> <http://example.com/base/name> "Beter & Leuk" .
+<http://example.com/base/subject> <http://example.com/base/name> "@7" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bakhuys Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Dr. Blend" .
+<http://example.com/base/subject> <http://example.com/base/name> "LITE/DARK" .
+<http://example.com/base/subject> <http://example.com/base/name> "Two for Joy" .
+<http://example.com/base/subject> <http://example.com/base/name> "Singel 404" .
+<http://example.com/base/subject> <http://example.com/base/name> "Yoghurt Barn" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bedford-Stuyvesant" .
+<http://example.com/base/subject> <http://example.com/base/name> "Nielsen" .
+<http://example.com/base/subject> <http://example.com/base/name> "My Little Patisserie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Back to Black" .
+<http://example.com/base/subject> <http://example.com/base/name> "Biologische Snackbar 't Wethoudertje" .
+<http://example.com/base/subject> <http://example.com/base/name> "Betty Blue" .
+<http://example.com/base/subject> <http://example.com/base/name> "Gs Amsterdam" .
+<http://example.com/base/subject> <http://example.com/base/name> "Pluk 9 Straatjes" .
+<http://example.com/base/subject> <http://example.com/base/name> "The Breakfast Club" .
+<http://example.com/base/subject> <http://example.com/base/name> "Toki" .
+<http://example.com/base/subject> <http://example.com/base/name> "De Bakkerswinkel" .
+<http://example.com/base/subject> <http://example.com/base/name> "Koffie Academie" .
+<http://example.com/base/subject> <http://example.com/base/name> "Salad & the City" .
+<http://example.com/base/subject> <http://example.com/base/name> "Coffee Room" .
+<http://example.com/base/subject> <http://example.com/base/name> "George W.P.A." .
+<http://example.com/base/subject> <http://example.com/base/name> "De Drie Graefjes" .
+<http://example.com/base/subject> <http://example.com/base/name> "Occo" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bagels & Beans" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lunchroom Lastig" .
+<http://example.com/base/subject> <http://example.com/base/name> "WIJS WEST" .
+<http://example.com/base/subject> <http://example.com/base/name> "Rein" .
+<http://example.com/base/subject> <http://example.com/base/name> "Bagels & Beans Amsterdam Oud West" .
+<http://example.com/base/subject> <http://example.com/base/name> "Lokaal Spaanders" .
+<http://example.com/base/subject> <http://example.com/base/name> "Twentyfiveseven" .

--- a/cypress/fixtures/sparql-editor/non-default-editor-configuration.json
+++ b/cypress/fixtures/sparql-editor/non-default-editor-configuration.json
@@ -1,0 +1,226 @@
+{
+  "namespace": "triply",
+  "val": {
+    "endpointHistory": [],
+    "tabs": [
+      "tnfzr",
+      "xn5jxw",
+      "002sj8",
+      "odh0q",
+      "twbizo"
+    ],
+    "active": "002sj8",
+    "tabConfig": {
+      "tnfzr": {
+        "yasqe": {
+          "value": "BASE <http://example.com/base/>\n\nSELECT * WHERE {\n  ?s ?p ?o .\n} LIMIT 100"
+        },
+        "yasr": {
+          "settings": {
+            "selectedPlugin": "table",
+            "pluginsConfig": {}
+          }
+        },
+        "requestConfig": {
+          "endpoint": "http://localhost:7333/repositories/ontorefine:123",
+          "method": "POST",
+          "acceptHeaderGraph": "application/n-triples,*/*;q=0.9",
+          "acceptHeaderSelect": "application/sparql-results+json,*/*;q=0.9",
+          "acceptHeaderUpdate": "text/plain,*/*;q=0.9",
+          "namedGraphs": [],
+          "defaultGraphs": [],
+          "args": [
+            {
+              "name": "dataProviderID",
+              "value": "ontorefine:123"
+            }
+          ],
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "withCredentials": false,
+          "adjustQueryBeforeRequest": false
+        },
+        "id": "tnfzr",
+        "name": "Unnamed"
+      },
+      "xn5jxw": {
+        "yasqe": {
+          "value": "BASE <http://example.com/base/>\n\nSELECT * WHERE {\n  ?s ?p ?o .\n} LIMIT 100"
+        },
+        "yasr": {
+          "settings": {
+            "selectedPlugin": "table",
+            "pluginsConfig": {}
+          }
+        },
+        "requestConfig": {
+          "endpoint": "http://localhost:7333/repositories/ontorefine:123",
+          "method": "POST",
+          "acceptHeaderGraph": "application/n-triples,*/*;q=0.9",
+          "acceptHeaderSelect": "application/sparql-results+json,*/*;q=0.9",
+          "acceptHeaderUpdate": "text/plain,*/*;q=0.9",
+          "namedGraphs": [],
+          "defaultGraphs": [],
+          "args": [
+            {
+              "name": "dataProviderID",
+              "value": "ontorefine:123"
+            }
+          ],
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "withCredentials": false,
+          "adjustQueryBeforeRequest": false
+        },
+        "id": "xn5jxw",
+        "name": "My new tab"
+      },
+      "002sj8": {
+        "yasqe": {
+          "value": "BASE <http://example.com/base/>\nSELECT * \nWHERE {\n  BIND( ?c_MC AS ?MC ) .\n  BIND( ?c_correct AS ?correct ) .\n  BIND( ?c_incorrect AS ?incorrect ) .\n}"
+        },
+        "yasr": {
+          "response": {
+            "contentType": "application/sparql-results+json;charset=UTF-8",
+            "data": "{\n  \"head\": {\n    \"vars\": [\n      \"MC\",\n      \"correct\",\n      \"incorrect\"\n    ]\n  },\n  \"results\": {\n    \"bindings\": [\n      {\n        \"MC\": {\n          \"type\": \"literal\",\n          \"value\": \"MA\"\n        }\n      },\n      {\n        \"MC\": {\n          \"type\": \"literal\",\n          \"value\": \"TF\"\n        }\n      },\n      {\n        \"MC\": {\n          \"type\": \"literal\",\n          \"value\": \"ESS\"\n        }\n      },\n      {\n        \"correct\": {\n          \"type\": \"literal\",\n          \"value\": \"Exponents\"\n        },\n        \"incorrect\": {\n          \"type\": \"literal\",\n          \"value\": \"Addition\"\n        },\n        \"MC\": {\n          \"type\": \"literal\",\n          \"value\": \"ORD\"\n        }\n      },\n      {\n        \"correct\": {\n          \"type\": \"literal\",\n          \"value\": \"dollars for students enrolled in\"\n        },\n        \"incorrect\": {\n          \"type\": \"literal\",\n          \"value\": \"units or more,\"\n        },\n        \"MC\": {\n          \"type\": \"literal\",\n          \"value\": \"FIB\"\n        }\n      },\n      {\n        \"correct\": {\n          \"type\": \"literal\",\n          \"value\": \"Λ\"\n        },\n        \"incorrect\": {\n          \"type\": \"literal\",\n          \"value\": \"γ\"\n        },\n        \"MC\": {\n          \"type\": \"literal\",\n          \"value\": \"MAT\"\n        }\n      }\n    ]\n  }\n}",
+            "status": 200,
+            "executionTime": 135,
+            "queryStartedTime": 1676380895969
+          },
+          "settings": {
+            "selectedPlugin": "table",
+            "pluginsConfig": {}
+          }
+        },
+        "requestConfig": {
+          "endpoint": "http://localhost:7333/repositories/ontorefine:123",
+          "method": "POST",
+          "acceptHeaderGraph": "application/n-triples,*/*;q=0.9",
+          "acceptHeaderSelect": "application/sparql-results+json,*/*;q=0.9",
+          "acceptHeaderUpdate": "text/plain,*/*;q=0.9",
+          "namedGraphs": [],
+          "defaultGraphs": [],
+          "args": [
+            {
+              "name": "dataProviderID",
+              "value": "ontorefine:123"
+            }
+          ],
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "withCredentials": false,
+          "adjustQueryBeforeRequest": false
+        },
+        "id": "002sj8",
+        "name": "Generated 1"
+      },
+      "odh0q": {
+        "yasqe": {
+          "value": "BASE <http://example.com/base/>\nSELECT * \nWHERE {\n  SERVICE <http://localhost:7333/repositories/ontorefine:2315541518351> {\n    BIND( ?c_MC AS ?MC ) .\n    BIND( ?c_What is 2+2? AS ?What is 2+2? ) .\n    BIND( ?c_4.0 AS ?4.0 ) .\n    BIND( ?c_correct AS ?correct ) .\n    BIND( ?c_3.0 AS ?3.0 ) .\n    BIND( ?c_incorrect AS ?incorrect ) .\n    BIND( ?c_Column 7 AS ?Column 7 ) .\n    BIND( ?c_Column 8 AS ?Column 8 ) .\n    BIND( ?c_Column 9 AS ?Column 9 ) .\n   }\n}"
+        },
+        "yasr": {
+          "settings": {
+            "selectedPlugin": "table",
+            "pluginsConfig": {}
+          }
+        },
+        "requestConfig": {
+          "endpoint": "http://localhost:7333/repositories/ontorefine:123",
+          "method": "POST",
+          "acceptHeaderGraph": "application/n-triples,*/*;q=0.9",
+          "acceptHeaderSelect": "application/sparql-results+json,*/*;q=0.9",
+          "acceptHeaderUpdate": "text/plain,*/*;q=0.9",
+          "namedGraphs": [],
+          "defaultGraphs": [],
+          "args": [
+            {
+              "name": "dataProviderID",
+              "value": "ontorefine:123"
+            }
+          ],
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "withCredentials": false,
+          "adjustQueryBeforeRequest": false
+        },
+        "id": "odh0q",
+        "name": "Generated 2"
+      },
+      "twbizo": {
+        "yasqe": {
+          "value": "BASE <http://example.com/base/>\n\nSELECT * WHERE {\n  ?s ?p ?o .\n} LIMIT 100"
+        },
+        "yasr": {
+          "settings": {
+            "selectedPlugin": "table",
+            "pluginsConfig": {}
+          }
+        },
+        "requestConfig": {
+          "endpoint": "http://localhost:7333/repositories/ontorefine:123",
+          "method": "POST",
+          "acceptHeaderGraph": "application/n-triples,*/*;q=0.9",
+          "acceptHeaderSelect": "application/sparql-results+json,*/*;q=0.9",
+          "acceptHeaderUpdate": "text/plain,*/*;q=0.9",
+          "namedGraphs": [],
+          "defaultGraphs": [],
+          "args": [
+            {
+              "name": "dataProviderID",
+              "value": "ontorefine:123"
+            }
+          ],
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "withCredentials": false,
+          "adjustQueryBeforeRequest": false
+        },
+        "id": "twbizo",
+        "name": "default query"
+      }
+    },
+    "lastClosedTab": {
+      "index": 2,
+      "tab": {
+        "yasqe": {
+          "value": "BASE <http://example.com/base/>\n\nSELECT * WHERE {\n  ?s ?p ?o .\n} LIMIT 100"
+        },
+        "yasr": {
+          "settings": {
+            "selectedPlugin": "table",
+            "pluginsConfig": {}
+          }
+        },
+        "requestConfig": {
+          "endpoint": "http://localhost:7333/repositories/ontorefine:123",
+          "method": "POST",
+          "acceptHeaderGraph": "application/n-triples,*/*;q=0.9",
+          "acceptHeaderSelect": "application/sparql-results+json,*/*;q=0.9",
+          "acceptHeaderUpdate": "text/plain,*/*;q=0.9",
+          "namedGraphs": [],
+          "defaultGraphs": [],
+          "args": [
+            {
+              "name": "dataProviderID",
+              "value": "ontorefine:123"
+            }
+          ],
+          "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          "withCredentials": false,
+          "adjustQueryBeforeRequest": false
+        },
+        "id": "pffdf",
+        "name": "Unnamed 1"
+      }
+    }
+  },
+  "exp": 2592000,
+  "time": 1676380896.107
+}

--- a/cypress/fixtures/sparql-editor/open-in-gdb-response
+++ b/cypress/fixtures/sparql-editor/open-in-gdb-response
@@ -1,0 +1,1 @@
+http://localhost:7200/sparql?query=BASE%20%3Chttp:%2F%2Fexample.com%2Fbase%2F%3E%0ASELECT%20*%20WHERE%20%7B%0A%20%20SERVICE%20%3Chttp:%2F%2Flocalhost:7333%2Frepositories%2Fontorefine:2463516846806%3E%20%7B%0A%20%20%20%20%3Fs%20%3Fp%20%3Fo%20.%0A%20%20%7D%0A%7D

--- a/cypress/fixtures/sparql-editor/simple-construct.sparql
+++ b/cypress/fixtures/sparql-editor/simple-construct.sparql
@@ -1,0 +1,10 @@
+BASE <http://example.com/base/>
+PREFIX mapper: <http://www.ontotext.com/mapper/>
+CONSTRUCT {
+  ?s1 <name> ?o_name .
+} WHERE {
+  SERVICE <http://localhost:4200/repositories/ontorefine:123>  {
+    BIND(<subject> as ?s1)
+    BIND(STR(?c_Title) as ?o_name)
+  }
+}

--- a/cypress/fixtures/sparql-editor/standard-query-generation.txt
+++ b/cypress/fixtures/sparql-editor/standard-query-generation.txt
@@ -1,0 +1,29 @@
+BASE <http://example.com/base/>
+SELECT * 
+WHERE {
+  BIND( ?c_Trcid AS ?Trcid ) .
+  BIND( ?c_Title AS ?Title ) .
+  BIND( ?c_Shortdescription AS ?Shortdescription ) .
+  BIND( ?c_Longdescription AS ?Longdescription ) .
+  BIND( ?c_Calendarsummary AS ?Calendarsummary ) .
+  BIND( ?c_TitleEN AS ?TitleEN ) .
+  BIND( ?c_ShortdescriptionEN AS ?ShortdescriptionEN ) .
+  BIND( ?c_LongdescriptionEN AS ?LongdescriptionEN ) .
+  BIND( ?c_CalendarsummaryEN AS ?CalendarsummaryEN ) .
+  BIND( ?c_Types AS ?Types ) .
+  BIND( ?c_Ids AS ?Ids ) .
+  BIND( ?c_Locatienaam AS ?Locatienaam ) .
+  BIND( ?c_City AS ?City ) .
+  BIND( ?c_Adres AS ?Adres ) .
+  BIND( ?c_Zipcode AS ?Zipcode ) .
+  BIND( ?c_Latitude AS ?Latitude ) .
+  BIND( ?c_Longitude AS ?Longitude ) .
+  BIND( ?c_Urls AS ?Urls ) .
+  BIND( ?c_Media AS ?Media ) .
+  BIND( ?c_Thumbnail AS ?Thumbnail ) .
+  BIND( ?c_Datepattern_startdate AS ?Datepattern_startdate ) .
+  BIND( ?c_Datepattern_enddate AS ?Datepattern_enddate ) .
+  BIND( ?c_Singledates AS ?Singledates ) .
+  BIND( ?c_Type1 AS ?Type1 ) .
+  BIND( ?c_Column AS ?Column ) .
+}

--- a/cypress/fixtures/sparql-editor/standard-with-service-query-generation.txt
+++ b/cypress/fixtures/sparql-editor/standard-with-service-query-generation.txt
@@ -1,0 +1,31 @@
+BASE <http://example.com/base/>
+SELECT * 
+WHERE {
+  SERVICE <http://localhost:4200/repositories/ontorefine:123> {
+    BIND( ?c_Trcid AS ?Trcid ) .
+    BIND( ?c_Title AS ?Title ) .
+    BIND( ?c_Shortdescription AS ?Shortdescription ) .
+    BIND( ?c_Longdescription AS ?Longdescription ) .
+    BIND( ?c_Calendarsummary AS ?Calendarsummary ) .
+    BIND( ?c_TitleEN AS ?TitleEN ) .
+    BIND( ?c_ShortdescriptionEN AS ?ShortdescriptionEN ) .
+    BIND( ?c_LongdescriptionEN AS ?LongdescriptionEN ) .
+    BIND( ?c_CalendarsummaryEN AS ?CalendarsummaryEN ) .
+    BIND( ?c_Types AS ?Types ) .
+    BIND( ?c_Ids AS ?Ids ) .
+    BIND( ?c_Locatienaam AS ?Locatienaam ) .
+    BIND( ?c_City AS ?City ) .
+    BIND( ?c_Adres AS ?Adres ) .
+    BIND( ?c_Zipcode AS ?Zipcode ) .
+    BIND( ?c_Latitude AS ?Latitude ) .
+    BIND( ?c_Longitude AS ?Longitude ) .
+    BIND( ?c_Urls AS ?Urls ) .
+    BIND( ?c_Media AS ?Media ) .
+    BIND( ?c_Thumbnail AS ?Thumbnail ) .
+    BIND( ?c_Datepattern_startdate AS ?Datepattern_startdate ) .
+    BIND( ?c_Datepattern_enddate AS ?Datepattern_enddate ) .
+    BIND( ?c_Singledates AS ?Singledates ) .
+    BIND( ?c_Type1 AS ?Type1 ) .
+    BIND( ?c_Column AS ?Column ) .
+   }
+}

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,4 +1,5 @@
 const cypressTypeScriptPreprocessor = require('./cy-ts-preprocessor');
+const fs = require('fs');
 
 module.exports = (on) =>
 {
@@ -8,5 +9,6 @@ module.exports = (on) =>
 module.exports = (on, config) => {
   on('task', {
     failed: require('cypress-failed-log/src/failed')(),
+    readFileOrNull: (file) => fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : null
   })
 };

--- a/cypress/steps/notification-steps.ts
+++ b/cypress/steps/notification-steps.ts
@@ -1,0 +1,33 @@
+import { AppComponentSelectors } from "../utils/selectors/app-component.selectors";
+
+/**
+ * Defines steps for the notifications during the functionality execution.
+ *
+ * @author A. Kunchev
+ */
+export default class NotificationSteps {
+
+  static getErrorNotification(): Cypress.Chainable {
+    return cy.get(AppComponentSelectors.ERROR_NOTIFICATION);
+  }
+
+  static getErrorNotificationContent(): Cypress.Chainable {
+    return this.getErrorNotification().get(AppComponentSelectors.NOTIFICATION_CONTENT);
+  }
+
+  static getWarnNotification(): Cypress.Chainable {
+    return cy.get(AppComponentSelectors.WARN_NOTIFICATION);
+  }
+
+  static getWarnNotificationContent(): Cypress.Chainable {
+    return this.getWarnNotification().get(AppComponentSelectors.NOTIFICATION_CONTENT);
+  }
+
+  static getSuccessfulNotification(): Cypress.Chainable {
+    return cy.get(AppComponentSelectors.SUCCESSFUL_NOTIFICATION);
+  }
+
+  static getSuccessfulNotificationContent(): Cypress.Chainable {
+    return this.getSuccessfulNotification().get(AppComponentSelectors.NOTIFICATION_CONTENT);
+  }
+}

--- a/cypress/steps/prepare-steps.ts
+++ b/cypress/steps/prepare-steps.ts
@@ -1,5 +1,6 @@
 import 'cypress-localstorage-commands';
-import {MapperComponentSelectors} from "../utils/selectors/mapper-component.selectors";
+import {MapperComponentSelectors} from '../utils/selectors/mapper-component.selectors';
+import {SparqlEditorComponentSelectors} from '../utils/selectors/sparql-editor-component.selectors';
 
 class PrepareSteps {
   static prepareMoviesNamespacesAndColumns() {
@@ -32,13 +33,40 @@ class PrepareSteps {
     });
   }
 
-  static visitPageAndWaitToLoad() {
+  static prepareQueriesGenerationResponses(): void {
+    cy.intercept('GET', '/rest/sparql-mapper/query?project=ontorefine:123&type=standard', {
+      fixture: 'sparql-editor/standard-query-generation'
+    });
+    cy.intercept('GET', '/rest/sparql-mapper/query?project=ontorefine:123&type=standard_with_service', {
+      fixture: 'sparql-editor/standard-with-service-query-generation'
+    });
+    cy.intercept('GET', '/rest/sparql-mapper/query?project=ontorefine:123&type=mapping_based', {
+      fixture: 'sparql-editor/mapping-based-query-generation'
+    });
+    cy.intercept('GET', '/rest/sparql-mapper/query?project=ontorefine:123&type=mapping_based_with_service', {
+      fixture: 'sparql-editor/mapping-based-with-service-query-generation'
+    });
+  }
+
+  static prepareEmptyEditorConfigurations(): void {
+    cy.intercept('GET', '/rest/sparql-mapper/editor-config?project=123', {
+      statusCode: 204
+    });
+  }
+
+  static visitPageAndWaitToLoad(): void {
     cy.visit('?dataProviderID=ontorefine:123');
     cy.wait(['@loadColumns', '@loadProject']);
     // Ensures the CELL_INPUT element is visible
     cy.get(`[appCypressData=${MapperComponentSelectors.CELL_INPUT}]`).should('be.visible');
     // TODO this is a very ugly solution to a problem caused by detached elements in the DOM
-    cy.wait(300)
+    cy.wait(300);
+  }
+
+  static visitPageAndOpenSparqlEditor(): void {
+    this.visitPageAndWaitToLoad();
+    cy.get(SparqlEditorComponentSelectors.TAB_ID).click();
+    cy.get(SparqlEditorComponentSelectors.YASGUI).should('be.visible');
   }
 }
 

--- a/cypress/steps/sparql-editor-steps.ts
+++ b/cypress/steps/sparql-editor-steps.ts
@@ -1,0 +1,144 @@
+import { SparqlEditorComponentSelectors } from "../utils/selectors/sparql-editor-component.selectors";
+
+const BE_VISIBLE = 'be.visible';
+
+export type QueryOption = 'standard' | 'standard-with-service' | 'mapping-based' | 'mapping-based-with-service';
+export type DownloadOption = 'query' | 'query-with-service' | 'result';
+
+/**
+ * Contains steps related to SPARQL Query Editor component.
+ * 
+ * @author A. Kunchev
+ */
+export default class SparqlEditorSteps {
+
+  static getEditorHostElement(): Cypress.Chainable {
+    return cy.get(SparqlEditorComponentSelectors.YASGUI_HOST);
+  }
+
+  static clickSave(): void {
+    cy.get(SparqlEditorComponentSelectors.SAVE_BTN).should(BE_VISIBLE).click();
+  }
+
+  static clickGenerateQuery(): void {
+    cy.get(SparqlEditorComponentSelectors.GENERATE_QUERY_BTN).should(BE_VISIBLE).click();
+    cy.get(SparqlEditorComponentSelectors.GENERATE_QUERY_MENU).should(BE_VISIBLE);
+  }
+
+  static clickQueryMenuOption(option: QueryOption): void {
+    const selector = SparqlEditorSteps.getOptionSelector(option);
+    cy.cypressData(selector).should(BE_VISIBLE).click();
+  }
+
+  static clickOpenInGraphDB(): void {
+    cy.get(SparqlEditorComponentSelectors.OPEN_IN_GRAPHDB_BTN).should(BE_VISIBLE).click();
+  }
+
+  static clickDownload(): void {
+    cy.get(SparqlEditorComponentSelectors.DOWNLOAD_BTN).should(BE_VISIBLE).click();
+    cy.get(SparqlEditorComponentSelectors.DOWNLOAD_MENU).should(BE_VISIBLE);
+  }
+
+  static clickDownloadMenuOption(option: DownloadOption): void {
+    const selector = SparqlEditorSteps.getOptionSelector(option);
+    cy.cypressData(selector).should(BE_VISIBLE).click();
+  }
+
+  static getDownloadResultWarningElement(): Cypress.Chainable {
+    return cy.get(`${SparqlEditorComponentSelectors.DOWNLOAD_MENU} .results-info-icon`);
+  }
+
+  static clickExecuteQuery(): void {
+    cy.get(SparqlEditorComponentSelectors.EXECUTE_QUERY_BTN).should(BE_VISIBLE).click();
+  }
+
+  static addNewEditorTab(): void {
+    cy.get(SparqlEditorComponentSelectors.YASGUI_ADD_TAB_BTN).should(BE_VISIBLE).click();
+  }
+
+  static getActiveTabContent(): Cypress.Chainable {
+    return cy.get(SparqlEditorComponentSelectors.ACTIVE_CODE_MIRROR)
+      // @ts-ignore
+      .then(($cm) => $cm.get(0).CodeMirror.getValue());
+  }
+
+  static setActiveTabContent(content: string): void {
+    cy.get(SparqlEditorComponentSelectors.ACTIVE_CODE_MIRROR)
+      // @ts-ignore
+      .then(($cm) => $cm.get(0).CodeMirror.setValue(content));
+  }
+
+  static getActiveTabElement(): Cypress.Chainable {
+    return cy.get(`${SparqlEditorComponentSelectors.YASGUI} [role="tab"][aria-selected="true"]`);
+  }
+
+  static renameActiveTab(name: string): void {
+    cy.get(`${SparqlEditorComponentSelectors.YASGUI} .tab.active`)
+      .should(BE_VISIBLE)
+      .dblclick()
+      .type('{selectall}{backspace}')
+      .type(`${name}{enter}`);
+  }
+
+  /**
+  * Generates random string and sets it as name of the currently active tab of the SPARQL editor.
+  *
+  * @returns the randomly generated name that was set for the tab
+  */
+  static setRandomTabName(): string {
+    const tabName = Math.random().toString(36).slice(2, 16);
+    SparqlEditorSteps.renameActiveTab(tabName);
+    return tabName;
+  }
+
+  static changeRenderMode(mode: 'standard' | 'editor-only' | 'results-only'): void {
+    let selector = 'render-yasgui-action';
+    if (mode === 'editor-only') {
+      selector = 'render-yasqe-action';
+    } else if (mode === 'results-only') {
+      selector = 'render-yasr-action';
+    }
+
+    cy.cypressData(selector).should(BE_VISIBLE).click();
+  }
+
+  static changeOrientation(): void {
+    cy.cypressData('change-orientation-action').should(BE_VISIBLE).click();
+  }
+
+  /**
+   * Retrieves the column element from the sources component at specific position starting from 0
+   * for the first element.
+   *
+   * The method ensures that the element is visible.
+   *
+   * @param index of the column element starting from 0 for the first
+   * @returns chainable with the column element
+   */
+  static getColumnNameElementAt(index: number): Cypress.Chainable {
+    return cy.get(SparqlEditorComponentSelectors.DATASET_COLUMNS_CONTAINER)
+      .cypressData(`source-${index}`)
+      .should(BE_VISIBLE);
+  }
+
+  private static getOptionSelector(option: QueryOption | DownloadOption): string {
+    switch (option) {
+      case 'standard':
+        return 'generate-template-action';
+      case 'standard-with-service':
+        return 'generate-template-with-service-action';
+      case 'mapping-based':
+        return 'generate-from-mapping-action';
+      case 'mapping-based-with-service':
+        return 'generate-from-mapping-with-service-action';
+      case 'query':
+        return 'download-sparql-action';
+      case 'query-with-service':
+        return 'download-sparql-with-service-action';
+      case 'result':
+        return 'download-result-action';
+      default:
+        throw new Error('Unsupported option: ' + option);
+    }
+  }
+}

--- a/cypress/test/sparlq-editor/binding-generation.cy.ts
+++ b/cypress/test/sparlq-editor/binding-generation.cy.ts
@@ -1,0 +1,79 @@
+import PrepareSteps from "../../steps/prepare-steps";
+import SparqlEditorSteps from "../../steps/sparql-editor-steps";
+
+// NOTE: would not work from columns which name is shortened
+function clickAndCheck(index: number): void {
+  let columnName = '';
+  SparqlEditorSteps.getColumnNameElementAt(index).then(($elem) => {
+    columnName = $elem.text().trim();
+    $elem.click();
+  });
+
+  SparqlEditorSteps.getActiveTabContent().then((query) => {
+    expect(query).to.contain(`BIND(?c_${columnName} as ?${columnName})`);
+  });
+}
+
+describe('SPARQL Query Editor: Bindings from Dataset Columns', () => {
+
+  beforeEach(() => {
+    PrepareSteps.prepareRestaurantsNamespacesAndColumns();
+    PrepareSteps.stubEmptyMappingModel();
+    PrepareSteps.prepareEmptyEditorConfigurations();
+  });
+
+  it('Should generate binding when column name is selected from sources component', () => {
+
+    // Given the editor is opens
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // And the active tab contains default query
+    cy.fixture('sparql-editor/default-sparql').then((expected) => {
+      SparqlEditorSteps.getActiveTabContent().then((query) => {
+        expect(expected).to.equal(query);
+      });
+    });
+
+    // When the column names are clicked
+    // Then the binding are inserted in the editor
+
+    // BIND(?c_Trcid as ?Trcid)
+    clickAndCheck(0);
+
+    // BIND(?c_Title as ?Title)
+    clickAndCheck(1);
+
+    // BIND(?c_Longdescription as ?Longdescription)
+    clickAndCheck(3);
+  });
+
+  it('Should generate binding when column name is selected for query with SERVICE clause', () => {
+
+    // Given the editor is opens
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // And the active tab contains default query with service
+    cy.fixture('sparql-editor/default-sparql-with-service').then((query) => {
+      SparqlEditorSteps.setActiveTabContent(query);
+    });
+
+    // (Known issue which will/should be addressed at some point)
+    // Replacing or changing the text in the editor does not trigger update of the editor
+    // configuration in the browser store
+
+    // forces the editor configuration be updated in the browser store
+    SparqlEditorSteps.renameActiveTab('sparql-with-service');
+
+    // When the column names are clicked
+    // Then the binding are inserted in the editor
+
+    // BIND(?c_Trcid as ?Trcid)
+    clickAndCheck(0);
+
+    // BIND(?c_Title as ?Title)
+    clickAndCheck(1);
+
+    // BIND(?c_Longdescription as ?Longdescription)
+    clickAndCheck(3);
+  });
+});

--- a/cypress/test/sparlq-editor/download-query-result.cy.ts
+++ b/cypress/test/sparlq-editor/download-query-result.cy.ts
@@ -1,0 +1,139 @@
+import { join } from "path";
+import NotificationSteps from "../../steps/notification-steps";
+import PrepareSteps from "../../steps/prepare-steps";
+import SparqlEditorSteps from "../../steps/sparql-editor-steps";
+
+describe('SPARQL Query Editor: Download Query Results', () => {
+
+  const downloadsFolder = Cypress.config('downloadsFolder')
+
+  beforeEach(() => {
+    PrepareSteps.prepareRestaurantsNamespacesAndColumns();
+    PrepareSteps.stubEmptyMappingModel();
+    PrepareSteps.prepareEmptyEditorConfigurations();
+  });
+
+  it('Should download file with RDF results when there is correct CONSTRUCT query', () => {
+    cy.intercept('POST', 'repositories/ontorefine:123', {
+      fixture: 'sparql-editor/download-query-results.ttl'
+    });
+
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Rename the default tab
+    const tabName = SparqlEditorSteps.setRandomTabName();
+
+    // Set CONSTRUCT SPARQL query
+    cy.fixture('sparql-editor/simple-construct.sparql').then((query: string) => {
+      SparqlEditorSteps.setActiveTabContent(query);
+    });
+
+    // Open the download menu
+    SparqlEditorSteps.clickDownload();
+
+    // Then the warning icon should not be visible
+    SparqlEditorSteps.getDownloadResultWarningElement().should('not.exist');
+
+    // When download results is selected
+    SparqlEditorSteps.clickDownloadMenuOption('result');
+
+    // Then the file should get the name of the active tab
+    const file = join(downloadsFolder, `${tabName}.ttl`);
+
+    // Then file download should be triggered
+    cy.readFile(file, { timeout: 2000 }).then((content) => {
+
+      // And the file content should be
+      cy.fixture('sparql-editor/download-query-results.ttl').then((expected: string) => {
+        expect(content).to.equal(expected);
+      });
+    });
+  });
+
+  it('Should show warning message when the editor contains SELECT query', () => {
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Rename the default tab
+    const tabName = SparqlEditorSteps.setRandomTabName();
+
+    // Open the download menu
+    SparqlEditorSteps.clickDownload();
+
+    // Then the warning icon should be visible
+    SparqlEditorSteps.getDownloadResultWarningElement().should('exist');
+
+    // When download results is selected
+    SparqlEditorSteps.clickDownloadMenuOption('result');
+
+    NotificationSteps.getWarnNotificationContent()
+      .contains('Download of the results is available only for CONSTRUCT queries.');
+
+    // Then the file should get the name of the active tab
+    const file = join(downloadsFolder, `${tabName}.ttl`);
+
+    // Then file download should be triggered
+    cy.task('readFileOrNull', file).should('not.exist');
+  });
+
+  it('Should show warning message when the editor is empty and download results is pressed', () => {
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Rename the default tab
+    const tabName = SparqlEditorSteps.setRandomTabName();
+
+    // Reset editor content
+    SparqlEditorSteps.setActiveTabContent('');
+
+    // Open the download menu
+    SparqlEditorSteps.clickDownload();
+
+    // Then the warning icon should be visible
+    SparqlEditorSteps.getDownloadResultWarningElement().should('exist');
+
+    // When download results is selected
+    SparqlEditorSteps.clickDownloadMenuOption('result');
+
+    NotificationSteps.getWarnNotificationContent()
+      .contains('Download of the results is available only for CONSTRUCT queries.');
+
+    // Then the file should get the name of the active tab
+    const file = join(downloadsFolder, `${tabName}.ttl`);
+
+    // Then file download should be triggered
+    cy.task('readFileOrNull', file).should('not.exist');
+  });
+
+  it('Should show error message when there is an error while executing the query on the server', () => {
+    cy.intercept('POST', 'repositories/ontorefine:123', {
+      statusCode: 500
+    });
+
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Rename the default tab
+    const tabName = SparqlEditorSteps.setRandomTabName();
+
+    // Set CONSTRUCT SPARQL query
+    cy.fixture('sparql-editor/simple-construct.sparql').then((query: string) => {
+      SparqlEditorSteps.setActiveTabContent(query);
+    });
+
+    // Open the download menu
+    SparqlEditorSteps.clickDownload();
+
+    // Then the warning icon should not be visible
+    SparqlEditorSteps.getDownloadResultWarningElement().should('not.exist');
+
+    // When download results is selected
+    SparqlEditorSteps.clickDownloadMenuOption('result');
+
+    // Then error notification should be shown
+    NotificationSteps.getErrorNotificationContent().then(($elem) => {
+      expect($elem).to.contain('500 Internal Server Error');
+    });
+
+    // And a file download should not be triggered
+    const file = join(downloadsFolder, `${tabName}.ttl`);
+    cy.task('readFileOrNull', file).should('not.exist');
+  });
+});

--- a/cypress/test/sparlq-editor/download-query.cy.ts
+++ b/cypress/test/sparlq-editor/download-query.cy.ts
@@ -1,0 +1,89 @@
+import { join } from "path";
+import NotificationSteps from "../../steps/notification-steps";
+import PrepareSteps from "../../steps/prepare-steps";
+import SparqlEditorSteps from "../../steps/sparql-editor-steps";
+
+describe('SPARQL Query Editor: Download Query', () => {
+
+  const downloadsFolder = Cypress.config('downloadsFolder')
+
+  beforeEach(() => {
+    PrepareSteps.prepareRestaurantsNamespacesAndColumns();
+    PrepareSteps.stubEmptyMappingModel();
+    PrepareSteps.prepareEmptyEditorConfigurations();
+  });
+
+  it('Should download file with SPARQL that is placed in the current tab of the editor', () => {
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Open the download menu
+    SparqlEditorSteps.clickDownload();
+
+    // And select query
+    SparqlEditorSteps.clickDownloadMenuOption('query');
+    
+    // Then the file should get the name of the active tab
+    const file = join(downloadsFolder, 'Unnamed.sparql');
+
+    // Then file download should be triggered
+    cy.readFile(file, { timeout: 2000 }).then((content) => {
+      // And the file content should be same as the one in the editor tab
+      cy.fixture('sparql-editor/download-default-sparql').then((expected: string) => {
+        expect(content).to.equal(expected);
+      });
+    });
+  });
+
+  it('Should download file containing the SPARQL from the current tab with SERVICE clause', () => {
+    cy.intercept('POST', '/rest/sparql-mapper/set-service', {
+      fixture: 'sparql-editor/default-sparql-with-service'
+    });
+
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Open the download menu
+    SparqlEditorSteps.clickDownload();
+
+    // And select query
+    SparqlEditorSteps.clickDownloadMenuOption('query-with-service');
+
+    // Then the file should get the name of the active tab
+    const file = join(downloadsFolder, 'Unnamed.sparql');
+
+    // Then file download should be triggered
+    cy.readFile(file, { timeout: 2000 }).then((content) => {
+
+      // And the file content should be same as the one in the editor tab
+      cy.fixture('sparql-editor/download-default-sparql-with-service').then((expected: string) => {
+        expect(content).to.equal(expected);
+      });
+    });
+  });
+
+  it('Should show error message when there is an service error and the file should not be download', () => {
+    cy.intercept('POST', '/rest/sparql-mapper/set-service', {
+      statusCode: 500
+    });
+
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Renames the tab, otherwise the check for the file existence fails,
+    // because the function detects the files from the previous tests
+    const tabName = SparqlEditorSteps.setRandomTabName();
+
+    // Open the download menu
+    SparqlEditorSteps.clickDownload();
+
+    // And select query
+    SparqlEditorSteps.clickDownloadMenuOption('query-with-service');
+
+    // Then error notification should be shown
+    NotificationSteps.getErrorNotificationContent().then(($elem) => {
+      expect($elem).to.contain('500 Internal Server Error');
+    });
+
+    // And a file download should not be triggered
+    const file = join(downloadsFolder, `${tabName}.sparql`);
+    cy.task('readFileOrNull', file).should('not.exist');
+  });
+});

--- a/cypress/test/sparlq-editor/editor-configuration.cy.ts
+++ b/cypress/test/sparlq-editor/editor-configuration.cy.ts
@@ -1,0 +1,149 @@
+import NotificationSteps from "../../steps/notification-steps";
+import PrepareSteps from "../../steps/prepare-steps";
+import SparqlEditorSteps from "../../steps/sparql-editor-steps";
+import { SparqlEditorComponentSelectors } from "../../utils/selectors/sparql-editor-component.selectors";
+
+describe('SPARQL Query Editor: Editor Configuration', () => {
+
+  beforeEach(() => {
+    PrepareSteps.prepareRestaurantsNamespacesAndColumns();
+    PrepareSteps.stubEmptyMappingModel();
+  });
+
+  context('Load Configuration', () => {
+
+    it('Should use the default configurations when there are not any stored on the server', () => {
+
+      // Given there are not configurations from the server
+      PrepareSteps.prepareEmptyEditorConfigurations();
+
+      // When the editor tab is opened
+      PrepareSteps.visitPageAndOpenSparqlEditor();
+
+      // Then the content of the active tab should be default query
+      cy.fixture('sparql-editor/default-sparql').then((expected) => {
+        SparqlEditorSteps.getActiveTabContent().then((query) => {
+          expect(expected).to.be.equal(query);
+        });
+      });
+
+      // And the tab should be have default naming
+      SparqlEditorSteps.getActiveTabElement().contains('Unnamed');
+
+      // And the results panel should not be visible
+      cy.get(SparqlEditorComponentSelectors.YASR).should('not.be.visible');
+
+      // And the 'save' button should be active
+      cy.get(SparqlEditorComponentSelectors.SAVE_BTN).should('be.enabled');
+    });
+
+    it('Should use the configurations returned from the server', () => {
+
+      // Given there are configurations from the server
+      cy.intercept('GET', '/rest/sparql-mapper/editor-config?project=123', {
+        fixture: 'sparql-editor/non-default-editor-configuration'
+      });
+
+      // When the editor tab is opened
+      PrepareSteps.visitPageAndOpenSparqlEditor();
+
+      // Then the content of the active tab should not be default query
+      cy.fixture('sparql-editor/default-sparql').then((expected) => {
+        SparqlEditorSteps.getActiveTabContent().then((query) => {
+          expect(expected).not.to.equal(query);
+        });
+      });
+
+      // And the tab should be have different than default naming
+      SparqlEditorSteps.getActiveTabElement().contains('Generated 1');
+
+      // And the results panel should be visible
+      cy.get(SparqlEditorComponentSelectors.YASR).should('be.visible');
+
+      // And the 'save' button should be active
+      cy.get(SparqlEditorComponentSelectors.SAVE_BTN).should('be.disabled');
+    });
+
+    it('Should show an error notification when the server returns status 500', () => {
+
+      // Given there are configurations from the server
+      cy.intercept('GET', '/rest/sparql-mapper/editor-config?project=123', {
+        statusCode: 500
+      });
+
+      // When the editor tab is opened
+      PrepareSteps.visitPageAndOpenSparqlEditor();
+
+      // Then notification should be shown for the server error
+      NotificationSteps.getErrorNotificationContent().contains('500 Internal Server Error');
+
+      // And the content of the active tab should be default query
+      cy.fixture('sparql-editor/default-sparql').then((expected) => {
+        SparqlEditorSteps.getActiveTabContent().then((query) => {
+          expect(expected).to.be.equal(query);
+        });
+      });
+
+      // And the tab should be have default naming
+      SparqlEditorSteps.getActiveTabElement().contains('Unnamed');
+
+      // And the results panel should not be visible
+      cy.get(SparqlEditorComponentSelectors.YASR).should('not.be.visible');
+
+      // And the 'save' button should be active
+      cy.get(SparqlEditorComponentSelectors.SAVE_BTN).should('be.enabled');
+    });
+  });
+
+  context('Save Configurations', () => {
+
+    it('Should save successfully the editor configuration', () => {
+
+      // returns OK for the save request
+      cy.intercept('POST', '/rest/sparql-mapper/editor-config', {
+        statusCode: 200
+      });
+
+      // Given there are not configurations from the server
+      PrepareSteps.prepareEmptyEditorConfigurations();
+
+      // When the editor tab is opened
+      PrepareSteps.visitPageAndOpenSparqlEditor();
+      
+      // Then the save button should be enabled
+      cy.get(SparqlEditorComponentSelectors.SAVE_BTN).should('be.enabled');
+
+      // When the 'Save' button is clicked
+      SparqlEditorSteps.clickSave();
+
+      // Then notification for successful save should be shown
+      NotificationSteps.getSuccessfulNotificationContent().contains('Current editor configuration was stored.');
+
+      // And the 'Save' button should be disabled
+      cy.get(SparqlEditorComponentSelectors.SAVE_BTN).should('be.disabled');
+    });
+
+    it('Should show notification when there is an server error during configuration saving', () => {
+
+      // returns OK for the save request
+      cy.intercept('POST', '/rest/sparql-mapper/editor-config', {
+        statusCode: 500
+      });
+
+      // Given there are not configurations from the server
+      PrepareSteps.prepareEmptyEditorConfigurations();
+
+      // When the editor tab is opened
+      PrepareSteps.visitPageAndOpenSparqlEditor();
+      
+      // Then the save button should be enabled
+      cy.get(SparqlEditorComponentSelectors.SAVE_BTN).should('be.enabled');
+
+      // When the 'Save' button is clicked
+      SparqlEditorSteps.clickSave();
+
+      // Then notification for successful save should be shown
+      NotificationSteps.getErrorNotificationContent().contains('500 Internal Server Error');
+    });
+  });
+});

--- a/cypress/test/sparlq-editor/editor-display-modes.cy.ts
+++ b/cypress/test/sparlq-editor/editor-display-modes.cy.ts
@@ -1,0 +1,150 @@
+import PrepareSteps from "../../steps/prepare-steps";
+import SparqlEditorSteps from "../../steps/sparql-editor-steps";
+import { SparqlEditorComponentSelectors } from "../../utils/selectors/sparql-editor-component.selectors";
+
+const BE_VISIBLE = 'be.visible';
+const NOT_BE_VISIBLE = 'not.be.visible';
+
+describe('SPARQL Query Editor: Display Modes', () => {
+
+  beforeEach(() => {
+    PrepareSteps.prepareRestaurantsNamespacesAndColumns();
+    PrepareSteps.stubEmptyMappingModel();
+    PrepareSteps.prepareEmptyEditorConfigurations();
+  });
+
+  it('Should switch to editor only mode', () => {
+
+    // Given the SPARQL Query Editor is opened
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Forces the results panel to be rendered
+    SparqlEditorSteps.clickExecuteQuery();
+
+    // And the results panel is visible
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+
+    // And the editor is visible
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+
+    // When the 'editor only' button is clicked
+    SparqlEditorSteps.changeRenderMode('editor-only');
+
+    // Then the results panel should be hidden
+    cy.get(SparqlEditorComponentSelectors.YASR).should(NOT_BE_VISIBLE);
+
+    // And the editor should remain visible
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+  });
+
+  it('Should switch to results only mode', () => {
+
+    // Given the SPARQL Query Editor is opened
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Forces the results panel to be rendered
+    SparqlEditorSteps.clickExecuteQuery();
+
+    // And the results panel is visible
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+
+    // And the editor is visible
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+
+    // When the 'results only' button is clicked
+    SparqlEditorSteps.changeRenderMode('results-only');
+
+    // Then the results panel should be visible
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+
+    // And the editor should be hidden
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(NOT_BE_VISIBLE);
+  });
+
+  it('Should switch to editor and results mode', () => {
+
+    // Given the SPARQL Query Editor is opened
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Forces the results panel to be rendered
+    SparqlEditorSteps.clickExecuteQuery();
+
+    // And the results panel is visible
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+
+    // And the editor is visible
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+
+    // And the 'results only' button is clicked
+    SparqlEditorSteps.changeRenderMode('results-only');
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(NOT_BE_VISIBLE);
+
+    // When the 'editor and results' button is clicked
+    SparqlEditorSteps.changeRenderMode('standard');
+
+    // Then the editor and results panels should be visible
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+  });
+
+  it('Should change the orientation of the editor', () => {
+
+    // Given the SPARQL Query Editor is opened
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Forces the results panel to be rendered
+    SparqlEditorSteps.clickExecuteQuery();
+
+    // And the results panel is visible
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+
+    // And the editor is visible
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+
+    // And to have default orientation
+    SparqlEditorSteps.getEditorHostElement().should('have.class', 'orientation-vertical');
+
+    // When the button for orientation is clicked
+    SparqlEditorSteps.changeOrientation();
+
+    // Then the editor should switch the orientation
+    SparqlEditorSteps.getEditorHostElement().should('have.class', 'orientation-horizontal');
+
+    // And the rendering mode should remain the same
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+  });
+
+  it('Should change the orientation of the editor and switch the rendering mode to default', () => {
+
+    // Given the SPARQL Query Editor is opened
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // Forces the results panel to be rendered
+    SparqlEditorSteps.clickExecuteQuery();
+
+    // And the results panel is visible
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+
+    // And the editor is visible
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+
+    // And to have default orientation
+    SparqlEditorSteps.getEditorHostElement().should('have.class', 'orientation-vertical');
+
+    // When the 'editor only' button is clicked
+    SparqlEditorSteps.changeRenderMode('editor-only');
+    cy.get(SparqlEditorComponentSelectors.YASR).should(NOT_BE_VISIBLE);
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+
+    // And the button for orientation is clicked
+    SparqlEditorSteps.changeOrientation();
+
+    // Then the orientation is changed
+    SparqlEditorSteps.getEditorHostElement().should('have.class', 'orientation-horizontal');
+
+    // And the rendering mode is switch to 'editor and results'
+    cy.get(SparqlEditorComponentSelectors.YASR).should(BE_VISIBLE);
+    cy.get(SparqlEditorComponentSelectors.YASQE).should(BE_VISIBLE);
+  });
+});

--- a/cypress/test/sparlq-editor/generate-query.cy.ts
+++ b/cypress/test/sparlq-editor/generate-query.cy.ts
@@ -1,0 +1,109 @@
+import NotificationSteps from '../../steps/notification-steps';
+import PrepareSteps from '../../steps/prepare-steps';
+import SparqlEditorSteps, {QueryOption} from '../../steps/sparql-editor-steps';
+
+/**
+ * Executes straightforward test case, where everything is working as expected. 
+ * 
+ * @param queryType the type of the query template that should be generated
+ * @param expectedFile the file containing the expected SPARQL query result
+ */
+function executeStraightforwardTest(queryType: QueryOption, expectedFile: string): void {
+  PrepareSteps.prepareQueriesGenerationResponses();
+
+  // Open SPARQL editor
+  PrepareSteps.visitPageAndOpenSparqlEditor();
+
+  // Open Generate Query Menu
+  SparqlEditorSteps.clickGenerateQuery();
+
+  // Select template option
+  SparqlEditorSteps.clickQueryMenuOption(queryType);
+
+  // New editor tab was opened
+  SparqlEditorSteps.getActiveTabElement().should(($elem) => {
+    expect($elem.first()).to.contain('Generated 1');
+  });
+
+  // And the content in it, is as expected
+  cy.fixture(expectedFile).then((expected) => {
+    SparqlEditorSteps.getActiveTabContent().then((query) => {
+      expect(expected).to.be.equal(query);
+    });
+  });
+}
+
+function executeErrorCaseTest(errorExpectedToContain: string): void {
+  // Open SPARQL editor
+  PrepareSteps.visitPageAndOpenSparqlEditor();
+
+  // Open Generate Query Menu
+  SparqlEditorSteps.clickGenerateQuery();
+
+  // Select template option
+  SparqlEditorSteps.clickQueryMenuOption('standard');
+
+  // The editor should remain on the initial tab
+  SparqlEditorSteps.getActiveTabElement().should(($elem) => {
+    expect($elem.first()).to.contain('Unnamed');
+  });
+
+  // There should be an error message
+  NotificationSteps.getErrorNotificationContent().should(($elem) => {
+    expect($elem).to.contain(errorExpectedToContain);
+  })
+}
+
+describe('SPARQL Query Editor: Generate Query', () => {
+
+  beforeEach(() => {
+    PrepareSteps.prepareRestaurantsNamespacesAndColumns();
+    PrepareSteps.stubEmptyMappingModel();
+    PrepareSteps.prepareEmptyEditorConfigurations();
+  });
+
+  context('Standard Queries Templates', () => {
+
+    it('Should generate SELECT query based on the project data columns', () => {
+      executeStraightforwardTest('standard', 'sparql-editor/standard-query-generation');
+    });
+
+    it('Should generate SELECT query with SERVICE clause based on the project data columns', () => {
+      executeStraightforwardTest(
+        'standard-with-service',
+        'sparql-editor/standard-with-service-query-generation');
+    });
+  });
+
+  context('From Mapping Query Templates', () => {
+
+    it('Should generate CONSTRUCT query based on mapping defined in Visual RDF Mapper', () => {
+      executeStraightforwardTest('mapping-based', 'sparql-editor/mapping-based-query-generation');
+    });
+
+    it('Should generate CONSTRUCT query with SERVICE clause based on mapping defined in Visual RDF Mapper', () => {
+      executeStraightforwardTest(
+        'mapping-based-with-service',
+        'sparql-editor/mapping-based-with-service-query-generation');
+    });
+  });
+
+  context('Error cases', () => {
+
+    it('Should receive an error message when there is an error on the server.', () => {
+      cy.intercept('GET', '/rest/sparql-mapper/query?project=ontorefine:123&type=standard', {
+        statusCode: 500
+      });
+
+      executeErrorCaseTest('500 Internal Server Error');
+    });
+
+    it('Should receive an error message when the endpoint is not found.', () => {
+      cy.intercept('GET', '/rest/sparql-mapper/query?project=ontorefine:123&type=standard', {
+        statusCode: 404
+      });
+
+      executeErrorCaseTest('404 Not Found');
+    });
+  });
+});

--- a/cypress/test/sparlq-editor/open-in-gdb.cy.ts
+++ b/cypress/test/sparlq-editor/open-in-gdb.cy.ts
@@ -1,0 +1,55 @@
+import NotificationSteps from "../../steps/notification-steps";
+import PrepareSteps from "../../steps/prepare-steps";
+import SparqlEditorSteps from "../../steps/sparql-editor-steps";
+
+describe('SPARQL Query Editor: Open in GraphDB', () => {
+
+  beforeEach(() => {
+    PrepareSteps.prepareRestaurantsNamespacesAndColumns();
+    PrepareSteps.stubEmptyMappingModel();
+    PrepareSteps.prepareEmptyEditorConfigurations();
+  });
+
+  it('Should open GraphDB workbench in new tab with the SPARQL from the active editor tab', () => {
+    cy.intercept('POST', 'rest/sparql-mapper/prepare-gdb-request', {
+      fixture: 'sparql-editor/open-in-gdb-response'
+    });
+
+    // stubs the opening of the new window tab
+    const stub = cy.stub().as('tabOpen');
+    cy.on('window:before:load', (win) => {
+      cy.stub(win.parent, 'open').callsFake(stub);
+    });
+
+    // Given SPARQL editor is opened
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // When the user clicks 'Open in GraphDB' button
+    SparqlEditorSteps.clickOpenInGraphDB();
+
+    // Then new tab should be opened
+    cy.get('@tabOpen').should('have.been.calledOnce').then((tabSpy: any) => {
+
+      // And the url lead to GraphDB Workbench
+      expect(tabSpy.getCall(0).args[0]).to.include('http://localhost:7200/sparql?query');
+    });
+  });
+
+  it('Should show error message and not open GraphDB workbench in new tab in case of server error', () => {
+    cy.intercept('POST', 'rest/sparql-mapper/prepare-gdb-request', {
+      statusCode: 500
+    });
+
+    // Given SPARQL editor is opened
+    PrepareSteps.visitPageAndOpenSparqlEditor();
+
+    // When the user clicks 'Open in GraphDB' button
+    SparqlEditorSteps.clickOpenInGraphDB();
+
+    // Then error notification is shown
+    NotificationSteps.getErrorNotificationContent().contains('500 Internal Server Error');
+
+    // And no new tab was opened
+    cy.url().should('equal', 'http://localhost:4200/?dataProviderID=ontorefine:123');
+  });
+});

--- a/cypress/utils/selectors/app-component.selectors.ts
+++ b/cypress/utils/selectors/app-component.selectors.ts
@@ -1,3 +1,7 @@
 export class AppComponentSelectors {
   static readonly APP_CONTENT_SELECTOR = 'content';
+  static readonly ERROR_NOTIFICATION = '.error-notification';
+  static readonly WARN_NOTIFICATION = '.warning-notification';
+  static readonly SUCCESSFUL_NOTIFICATION = '.success-notification';
+  static readonly NOTIFICATION_CONTENT = '.mat-simple-snack-bar-content'
 }

--- a/cypress/utils/selectors/mapper-component.selectors.ts
+++ b/cypress/utils/selectors/mapper-component.selectors.ts
@@ -56,6 +56,4 @@ export class MapperComponentSelectors {
   static readonly TYPE_LITERAL = 'type-literal';
   static readonly TYPE_UNIQUE_BNODE = 'type-unique_bnode';
   static readonly TYPE_VALUE_BNODE = 'type-value_bnode';
-
-
 }

--- a/cypress/utils/selectors/sparql-editor-component.selectors.ts
+++ b/cypress/utils/selectors/sparql-editor-component.selectors.ts
@@ -1,0 +1,22 @@
+/**
+ * Contains constants with selectors for the SPARQL Query Editor.
+ * 
+ * @author A. Kunchev
+ */
+export class SparqlEditorComponentSelectors {
+  static readonly TAB_ID = '#mat-tab-label-0-1';
+  static readonly YASGUI_HOST = '.sparql-editor-container .yasgui-host-element';
+  static readonly YASGUI = '.yasgui';
+  static readonly YASGUI_ADD_TAB_BTN = '.addTab';
+  static readonly YASQE = '.yasqe';
+  static readonly ACTIVE_CODE_MIRROR = '.active .CodeMirror';
+  static readonly YASR = '.yasr';
+  static readonly SAVE_BTN = '.save-primary';
+  static readonly GENERATE_QUERY_BTN = '.template-options';
+  static readonly GENERATE_QUERY_MENU = '.queries-template-menu';
+  static readonly OPEN_IN_GRAPHDB_BTN = '.open-gdb-primary';
+  static readonly DOWNLOAD_BTN = '.download-options';
+  static readonly DOWNLOAD_MENU = '.download-menu';
+  static readonly EXECUTE_QUERY_BTN = '.yasqe_queryButton';
+  static readonly DATASET_COLUMNS_CONTAINER = '.editor-top-header .rdfm-columns-container';
+}

--- a/src/app/main/mapper/mapper.component.html
+++ b/src/app/main/mapper/mapper.component.html
@@ -6,14 +6,14 @@
     </div>
 
     <div class="content">
-      <div class="mr-12">
+      <div>
         <mat-form-field appearance="fill">
           <mat-label>{{'LABELS.BASE_IRI' | translate}}</mat-label>
           <input matInput [ngModel]="getBaseIRI()" (ngModelChange)="setBaseIRI($event)" appCypressData="base-iri">
         </mat-form-field>
       </div>
 
-      <div class="mr-12">
+      <div>
         <mat-form-field>
           <mat-chip-list #namespaces area-label="Namespaces management" appCypressData="namespace-wrapper" [selectable]="true">
             <mat-chip *ngFor="let namespace of getNamespaces() | keyvalue" (removed)="removeNamespace(namespace.key)"

--- a/src/app/main/sparql-editor/editor-header/editor-header.component.html
+++ b/src/app/main/sparql-editor/editor-header/editor-header.component.html
@@ -44,7 +44,7 @@
       {{"BUTTONS.GENERATE_QUERY" | translate}}
       <mat-icon class="ml-1">arrow_drop_down</mat-icon>
     </button>
-    <mat-menu #templateMenu="matMenu" xPosition="before">
+    <mat-menu #templateMenu="matMenu" xPosition="before" class="queries-template-menu">
       <button mat-menu-item
               appCypressData="generate-template-action"
               (click)="generateSparql(generationSparqlType.STANDARD)"
@@ -97,7 +97,7 @@
       {{"BUTTONS.DOWNLOAD" | translate}}
       <mat-icon class="ml-1">arrow_drop_down</mat-icon>
     </button>
-    <mat-menu #downloadMenu="matMenu" xPosition="before">
+    <mat-menu #downloadMenu="matMenu" xPosition="before" class="download-menu">
       <button mat-menu-item
               appCypressData="download-sparql-action"
               (click)="downloadSparql(downloadSparqlType.DEFAULT)"

--- a/src/app/main/sparql-editor/sparql-editor.component.ts
+++ b/src/app/main/sparql-editor/sparql-editor.component.ts
@@ -381,7 +381,7 @@ export class SparqlEditorComponent extends OnDestroyMixin implements OnInit {
 
     sparql = this.tryToFormat(sparql, true);
 
-    const column = source.getTitle().replace(/\s+/g, '_');
+    const column = source.getTitle();
     const updatedSparql = this.insetColumnBinding(sparql, column);
 
     const newEditorConfig = {...this.getCurrentYasguiConfig()};

--- a/src/app/services/error-reporter.service.ts
+++ b/src/app/services/error-reporter.service.ts
@@ -25,16 +25,16 @@ export class ErrorReporterService {
     let errorMessage = message;
     if (error.error instanceof ErrorEvent) {
       errorMessage = this.clientError(error, notify);
-      throwError(errorMessage);
+      throwError(() => new Error(errorMessage));
     } else {
       const errMessage = this.backendError(error, message, notify);
       if (errMessage instanceof Promise) {
-        errMessage.then((err) => throwError(err));
+        errMessage.then((err) => throwError(() => new Error(err)));
       } else {
-        return throwError(errorMessage);
+        return throwError(() => new Error(errorMessage));
       }
     }
-    return throwError(errorMessage);
+    return throwError(() => new Error(errorMessage));
   }
 
   clientError(error: any, notify: boolean) {
@@ -62,7 +62,7 @@ export class ErrorReporterService {
       } else {
         errorMessage = error.message;
       }
-      this.notify(notify, errorMessage);
+      this.notify(notify, errorMessage || message);
       return errorMessage;
     }
   }


### PR DESCRIPTION
- Added tests for the SPARQL editor that were left unfinished in the previous pull request, where the editor was introduced in the Mapping-UI.

  The tests are covering the straightforward and some edge cases. They
are not so extensive as there are acceptance tests, which are covering large portion of the functionalities.

- Added some fixes and improvements discovered during the testing process.